### PR TITLE
Replace term backend with adapter

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
-Juttle InfluxDB Backend
+Juttle InfluxDB Adapter
 Copyright 2015 Jut, Inc.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Juttle InfluxDB Backend
+# Juttle InfluxDB Adapter
 
-[![Build Status](https://travis-ci.com/juttle/juttle-influx-backend.svg?token=C2AjzxBQoVUrmWXFQb7w)](https://travis-ci.com/juttle/juttle-influx-backend)
+[![Build Status](https://travis-ci.com/juttle/juttle-influx-adapter.svg?token=C2AjzxBQoVUrmWXFQb7w)](https://travis-ci.com/juttle/juttle-influx-adapter)
 
-Juttle InfluxDB backend for the [Juttle data flow
+Juttle InfluxDB adapter for the [Juttle data flow
 language](https://github.com/juttle/juttle), with read & write support. Large
 part of InfluxQL SELECT syntax is accessible through options and raw mode is
 also available as a fallback.
@@ -25,23 +25,23 @@ emit -points [{ value: 0.01 }] | write influx -db 'test' -measurement 'cpu'
 
 ## Installation
 
-Like Juttle itself, the backend is installed as a npm package. Both Juttle and
-the backend need to be installed side-by-side:
+Like Juttle itself, the adapter is installed as a npm package. Both Juttle and
+the adapter need to be installed side-by-side:
 
 ```bash
 $ npm install juttle
-$ npm install juttle-influx-backend
+$ npm install juttle-influx-adapter
 ```
 
 ## Configuration
 
-The backend needs to be registered and configured so that it can be used from
+The adapter needs to be registered and configured so that it can be used from
 within Juttle. To do so, add the following to your `~/.juttle/config.json` file:
 
 ```json
 {
-    "backends": {
-        "influx-backend": {
+    "adapters": {
+        "influx-adapter": {
             "url": "http://localhost:8086/"
         }
     }
@@ -61,7 +61,7 @@ When storing points, the following conventions are used:
    `bar` as fields, not tags.
 
 2. InfluxDB distinguishes between integers and floating point numeric types. By
-   default, the backend stores all numeric fields as floats. This can be changed
+   default, the adapter stores all numeric fields as floats. This can be changed
    by enumerating the integer fields via `intFields` option.
 
 ### Read options

--- a/index.js
+++ b/index.js
@@ -189,7 +189,7 @@ var Read = Juttle.proc.source.extend({
     },
 });
 
-function InfluxBackend(cfg) {
+function InfluxAdapter(cfg) {
     config = cfg;
     return {
         name: 'influx',
@@ -198,4 +198,4 @@ function InfluxBackend(cfg) {
     };
 }
 
-module.exports = InfluxBackend;
+module.exports = InfluxAdapter;

--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
 {
-  "name": "juttle-influx-backend",
+  "name": "juttle-influx-adapter",
   "version": "0.1.0",
-  "description": "Juttle backend for InfluxDB",
+  "description": "Juttle adapter for InfluxDB",
   "main": "index.js",
   "scripts": {
     "test": "mocha"
   },
   "repository": {
     "type": "git",
-    "url": "http://github.com/juttle/juttle-influx-backend"
+    "url": "http://github.com/juttle/juttle-influx-adapter"
   },
   "author": "Balazs Kutil <balazs@jut.io>",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/juttle/juttle-influx-backend/issues"
+    "url": "https://github.com/juttle/juttle-influx-adapter/issues"
   },
-  "homepage": "https://github.com/juttle/juttle-influx-backend",
+  "homepage": "https://github.com/juttle/juttle-influx-adapter",
   "dependencies": {
     "glob-to-regexp": "^0.1.0",
     "bluebird": "^3.0.5",

--- a/test/influx-live.spec.js
+++ b/test/influx-live.spec.js
@@ -18,7 +18,7 @@ var retry_options = { interval: 50, timeout: 250 };
 
 
 var Juttle = require('juttle/lib/runtime').Juttle;
-Juttle.backends.register('influx', influx({
+Juttle.adapters.register('influx', influx({
     url: url.format(influx_api_url)
 }, Juttle));
 


### PR DESCRIPTION
Rename files, replace usage in code, docs, package.json, repo names and urls

refs: https://github.com/juttle/juttle/pull/269
