### PR TITLE
Remove logOnce calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,6 @@ var Write = Juttle.proc.sink.extend({
                 return self.serializer.toInflux(p);
             } catch(err) {
                 self.trigger('warning', err);
-                self.logOnce('error', err.message);
                 return null;
             }
         })).join("\n");
@@ -66,7 +65,6 @@ var Write = Juttle.proc.sink.extend({
             }
         }).catch(function(err) {
             self.trigger('error', err);
-            self.logOnce('error', err.message);
             self.done();
         });
     }
@@ -114,7 +112,6 @@ var Read = Juttle.proc.source.extend({
             self.emit_eof();
         }).catch(function(err) {
             self.trigger('error', err);
-            self.logOnce('error', err.message);
             self.emit_eof();
         });
     },


### PR DESCRIPTION
The `logOnce` method was removed from `Juttle.proc.base`. The new policy is that the client is responsible for logging error/warning events.
