### PR TITLE
Drop sourceType property from read

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,6 @@ var Write = Juttle.proc.sink.extend({
 });
 
 var Read = Juttle.proc.source.extend({
-    sourceType: 'batch',
     procName: 'read-influx',
 
     initialize: function(options, params, pname, location, program, juttle) {


### PR DESCRIPTION
As read now inherits from Juttle source proc and program checks for
that, the sourceType property is not needed.

refs: https://github.com/juttle/juttle/pull/110