### PR TITLE
Fix filter AST lint dealing with time

### DIFF
--- a/lib/ast/lint.js
+++ b/lib/ast/lint.js
@@ -16,27 +16,11 @@ var Lints = {
 
 // Duration comparisons are not supported (they could be converted to moments, though)
 _.each([
-    'MomentDuration',
-    'CalendarExpression',
-    'YesterDayLiteral',
-    'TodayLiteral',
-    'TomorrowLiteral',
-    'ISODateLiteral',
-    'NowLiteral'
+    'MomentLiteral',
+    'DurationLiteral'
 ], function(node) {
     Lints['visit' + node] = function() {
         throw new Error('Filtering by time is not supported');
-    };
-});
-
-// Beginning/end/forever are illegal
-_.each([
-    'BeginningLiteral',
-    'EndLiteral',
-    'ForeverLiteral',
-], function(node) {
-    Lints['visit' + node] = function(node) {
-        throw new Error('Node ' + node.value + ' cannot be used in filter');
     };
 });
 

--- a/test/ast/lint.spec.js
+++ b/test/ast/lint.spec.js
@@ -44,7 +44,7 @@ describe('query linting', function() {
 
         _.each(tests, function(test) {
             var ast = parser.parseFilter(test);
-            expect(linter.lint.bind(linter, ast)).to.throw(/cannot be used in filter/);
+            expect(linter.lint.bind(linter, ast)).to.throw(/Filtering by time is not supported/);
         });
     });
 });


### PR DESCRIPTION
The MomentContstant and DurationConstant were renamed to MomentLiteral
and DurationLiteral, respectively. Update the checks prohibiting
filtering on time and the tests to reflect that.

Also remove names of AST nodes which would not occur in a 'real' world
scenarios - they're converted by a semantic pass.