### PR TITLE
Add support for serializing objects/arrays

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -3,6 +3,7 @@
  */
 
 var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
+var values = require('juttle/lib/runtime/values');
 var _ = require('underscore');
 
 var Serializer = function(options) {
@@ -62,17 +63,20 @@ Serializer.prototype._concatKeyVal = function(v, k) {
 };
 
 Serializer.prototype._serializeValue = function(v, k) {
-    if (_.isBoolean(v)) {
+    if (values.isBoolean(v)) {
         return [k, (v ? 't' : 'f')];
     } else
-    if (_.isString(v)) {
+    if (values.isString(v)) {
         return [k, '"' + this._escapeString(v) + '"'];
     } else
     if (this._isInt(v, k)) {
         return [k, Math.floor(v) + 'i'];
     } else
-    if (v instanceof JuttleMoment) {
+    if (values.isDate(v) || values.isDuration(v)) {
         return [k, v.unixms()];
+    } else
+    if (values.isObject(v) || values.isArray(v)) {
+        throw new Error('Serializing array and object fields is not supported.');
     } else {
         return [k, v];
     }

--- a/test/influx-live.spec.js
+++ b/test/influx-live.spec.js
@@ -334,6 +334,24 @@ describe('@live influxdb tests', function () {
             });
         });
 
+        it('point with array triggers a warning', function() {
+            return check_juttle({
+                program: 'emit -limit 1 | put host = "host0", value = [1,2,3] | write influx -db "test" -measurement "cpu"'
+            }).then(function(res) {
+                expect(res.warnings.length).to.not.equal(0);
+                expect(res.warnings[0]).to.include('not supported');
+            });
+        });
+
+        it('point with object triggers a warning', function() {
+            return check_juttle({
+                program: 'emit -limit 1 | put host = "host0", value = {k:"v"} | write influx -db "test" -measurement "cpu"'
+            }).then(function(res) {
+                expect(res.warnings.length).to.not.equal(0);
+                expect(res.warnings[0]).to.include('not supported');
+            });
+        });
+
         it('valFields override', function() {
             return check_juttle({
                 program: 'emit -points [{"host":"host0","value":0,"str":"value"}] | write influx -db "test" -measurement "cpu" -valFields "str"'

--- a/test/serializer.spec.js
+++ b/test/serializer.spec.js
@@ -142,6 +142,16 @@ describe('serialization', function() {
             expect(serializer.toInflux(point)).to.equal('m num=1e+21');
         });
 
+        it('serializing object fields throws an error', function() {
+            var point = { obj: { k: "v" }, _measurement: 'm' };
+            expect(serializer.toInflux.bind(serializer, point)).to.throw(Error, /not supported/);
+        });
+
+        it('serializing array fields throws an error', function() {
+            var point = { arr: [1,2,3], _measurement: 'm' };
+            expect(serializer.toInflux.bind(serializer, point)).to.throw(Error, /not supported/);
+        });
+
         describe('measurement option', function() {
             it('is used as a fallback w/o measurementField', function() {
                 var serializer = new Serializer({measurement: 'm'});


### PR DESCRIPTION
As core Juttle now handles fields whose values are arrays or objects,
add support for serializing those points into JSON.