### PR TITLE
Optimize head and tail

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 var Read = require('./lib/read');
 var Write = require('./lib/write');
+var Optimizer = require('./lib/query/optimize');
 var config = require('./lib/config');
 
 function InfluxAdapter(cfg) {
@@ -9,7 +10,8 @@ function InfluxAdapter(cfg) {
     return {
         name: 'influx',
         read: Read,
-        write: Write
+        write: Write,
+        optimizer: Optimizer
     };
 }
 

--- a/lib/query/optimize.js
+++ b/lib/query/optimize.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var optimizer = {
+    optimize_head(read, head, graph, info) {
+        var limit = graph.node_get_option(head, 'arg');
+
+        var opt = { type: 'head', options: { limit: limit, orderBy: 'time', orderDescending: false } };
+
+        Object.assign(info, opt);
+
+        return true;
+    },
+
+    // The tail optimization relies on an explicit sort by time that occurs after
+    // fetching points, so we don't have to reverse the result set.
+    optimize_tail(read, tail, graph, info) {
+        var limit = graph.node_get_option(tail, 'arg');
+
+        var opt = { type: 'tail', options: { limit: limit, orderBy: 'time', orderDescending: true} };
+
+        Object.assign(info, opt);
+
+        return true;
+    }
+};
+
+module.exports = optimizer;

--- a/lib/query/select.js
+++ b/lib/query/select.js
@@ -108,7 +108,13 @@ class SelectBuilder {
     }
 
     _orderBy(options, filter_ast) {
-        // FIXME
+        if (options.orderBy) {
+            // FIXME: handle arrays
+            var orderDirection = options.orderDescending ? 'DESC' : 'ASC';
+            return ['ORDER BY', options.orderBy, orderDirection].join(' ');
+        } else {
+            return null;
+        }
     }
 }
 

--- a/lib/read.js
+++ b/lib/read.js
@@ -18,7 +18,7 @@ class ReadInflux extends AdapterRead {
         super(options, params);
 
         var allowed_options = AdapterRead.commonOptions.concat([
-            'raw', 'db', 'offset', 'limit', 'fields', 'nameField'
+            'raw', 'db', 'offset', 'limit', 'fields', 'nameField', 'optimize'
         ]);
         var unknown = _.difference(_.keys(options), allowed_options);
 
@@ -49,13 +49,17 @@ class ReadInflux extends AdapterRead {
         this.db = options.db;
 
         this.queryBuilder = new QueryBuilder();
+        this.queryOptimization = params.optimization_info;
+
         this.queryOptions = _.defaults(
             _.pick(options, 'offset', 'limit', 'fields', 'raw'),
+            this.queryOptimization.options || {},
             {
                 nameField: this.nameField,
                 limit: 1000,
             }
         );
+
         this.queryFilter  = params;
     }
 

--- a/test/influx-live.spec.js
+++ b/test/influx-live.spec.js
@@ -214,8 +214,6 @@ describe('@live influxdb tests', function () {
             });
         });
 
-        it.skip('order by', function() {});
-
         describe('filters', function() {
             it('on tags', function() {
                 return check_juttle({

--- a/test/influx-live.spec.js
+++ b/test/influx-live.spec.js
@@ -326,6 +326,81 @@ describe('@live influxdb tests', function () {
                 });
             });
         });
+
+        describe('optimizations', function() {
+            describe('head', function() {
+                it('head n', function() {
+                    return check_juttle({
+                        program: 'read influx -db "test" -from :0: name = "cpu" | head 3 | view logger'
+                    }).then(function(res) {
+                        expect(res.sinks.logger.length).to.equal(3);
+                    });
+                });
+
+                it('head n, unoptimized', function() {
+                    return check_juttle({
+                        program: 'read influx -optimize false -db "test" -from :0: name = "cpu" | head 3 | view logger'
+                    }).then(function(res) {
+                        expect(res.sinks.logger.length).to.equal(3);
+                    });
+                });
+
+                it('head n doesnt override limit', function() {
+                    return check_juttle({
+                        program: 'read influx -db "test" -limit 1 -from :0: name = "cpu" | head 3 | view logger'
+                    }).then(function(res) {
+                        expect(res.sinks.logger.length).to.equal(1);
+                    });
+                });
+
+                it('head n doesnt override limit, unoptimized', function() {
+                    return check_juttle({
+                        program: 'read influx -optimize false -db "test" -limit 1 -from :0: name = "cpu" | head 3 | view logger'
+                    }).then(function(res) {
+                        expect(res.sinks.logger.length).to.equal(1);
+                    });
+                });
+            });
+
+            describe('tail', function() {
+                it('tail n', function() {
+                    return check_juttle({
+                        program: 'read influx -db "test" -from :0: name = "cpu" | tail 3 | view logger'
+                    }).then(function(res) {
+                        expect(res.sinks.logger.length).to.equal(3);
+                        expect(res.sinks.logger[0].value).to.equal(7);
+                        expect(res.sinks.logger[2].value).to.equal(9);
+                    });
+                });
+
+                it('tail n, unoptimized', function() {
+                    return check_juttle({
+                        program: 'read influx -optimize false -db "test" -from :0: name = "cpu" | tail 3 | view logger'
+                    }).then(function(res) {
+                        expect(res.sinks.logger.length).to.equal(3);
+                        expect(res.sinks.logger[0].value).to.equal(7);
+                        expect(res.sinks.logger[2].value).to.equal(9);
+                    });
+                });
+
+                it('tail n doesnt override limit', function() {
+                    return check_juttle({
+                        program: 'read influx -db "test" -limit 1 -from :0: name = "cpu" | tail 3 | view logger'
+                    }).then(function(res) {
+                        expect(res.sinks.logger.length).to.equal(1);
+                    });
+                });
+
+                it('tail n doesnt override limit, unoptimized', function() {
+                    return check_juttle({
+                        program: 'read influx -optimize false -db "test" -limit 1 -from :0: name = "cpu" | tail 3 | view logger'
+                    }).then(function(res) {
+                        expect(res.sinks.logger.length).to.equal(1);
+                    });
+                });
+            });
+        });
+
     });
 
     describe('write', function() {

--- a/test/query/query.spec.js
+++ b/test/query/query.spec.js
@@ -67,6 +67,20 @@ describe('influxql query building', function() {
             });
         });
 
+        describe('ORDER BY', function() {
+            it('adds clause', function() {
+                expect(builder.build({ orderBy: 'time', nameField: 'name' })).to.equal('SELECT * FROM /.*/ ORDER BY time ASC');
+            });
+
+            it('adds clause for direction', function() {
+                expect(builder.build({ orderBy: 'time', orderDescending: true, nameField: 'name' })).to.equal('SELECT * FROM /.*/ ORDER BY time DESC');
+            });
+
+            it('correct order with limit', function() {
+                expect(builder.build({ offset: 1, limit: 2, orderBy: 'time', nameField: 'name' })).to.equal('SELECT * FROM /.*/ ORDER BY time ASC LIMIT 2 OFFSET 1');
+            });
+        });
+
         describe('WHERE', function() {
             it('simple filter', function() {
                 var ast = utils.parseFilter('key = 1');


### PR DESCRIPTION
Add support for head and tail optimisations and tests. `tail by` and `head by` are not supported.

refs: #39 