### PR TITLE
travis: remove duplicate node_js section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,6 @@ node_js:
     - '4.2'
     - '5.0'
 
-node_js:
-    - '4.2'
-    - '5.0'
-
 services:
     - docker
 


### PR DESCRIPTION
Fix a simple typo in which the node_js section was duplicated.

@bkutil 