### PR TITLE
read.js - move URL validation to constructor

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -31,7 +31,7 @@ var Read = Juttle.proc.source.extend({
         this.nameField = options.nameField || 'name';
         this.serializer = new Serializer();
 
-        this.url = Config.get().url;
+        this.url = this.setUrl(Config.get().url);
         this.db = options.db;
 
         this.queryBuilder = new QueryBuilder();
@@ -45,6 +45,22 @@ var Read = Juttle.proc.source.extend({
         this.queryFilter  = params;
 
         this.raw = options.raw;
+    },
+
+    setUrl: function(urlStr) {
+        var urlObj = {};
+
+        try {
+            urlObj = url.parse(urlStr);
+        } catch (e) {
+            throw new this.runtime_error('RT-INVALID-URL-ERROR', { url: urlStr });
+        }
+
+        if (!urlObj.host) {
+            throw new this.runtime_error('RT-INVALID-URL-ERROR', { url: urlStr });
+        }
+
+        return urlObj;
     },
 
     start: function() {
@@ -109,32 +125,24 @@ var Read = Juttle.proc.source.extend({
     },
 
     fetch: function() {
-        var parsedUrl = url.parse(this.url);
+        var parsedUrl = _.clone(this.url);
         var reqUrl = null;
 
         var query = this.raw ? this.raw : this.queryBuilder.build(this.queryOptions, this.queryFilter);
 
         _.extend(parsedUrl, { pathname: '/query', query: { 'q': query, 'db': this.db, 'epoch' : 'ms' } });
 
-        reqUrl = url.format(parsedUrl);
-
-        if (!parsedUrl.host) {
-            return Promise.reject(new this.runtime_error('RT-INVALID-URL-ERROR',
-                { url: reqUrl }
-            ));
-        } else {
-            return request.async({
-                url: reqUrl,
-                method: 'GET'
-            }).then(function(response) {
-                if (response.statusCode < 200 || response.statusCode >= 300) {
-                    throw new Error(response.statusCode + ': ' + response.body + ' for ' + reqUrl);
-                }
-                return JSON.parse(response.body);
-            }).catch(function(e) {
-                throw e;
-            });
-        }
+        return request.async({
+            url: url.format(parsedUrl),
+            method: 'GET'
+        }).then(function(response) {
+            if (response.statusCode < 200 || response.statusCode >= 300) {
+                throw new Error(response.statusCode + ': ' + response.body + ' for ' + reqUrl);
+            }
+            return JSON.parse(response.body);
+        }).catch(function(e) {
+            throw e;
+        });
     },
 });
 


### PR DESCRIPTION
The URL option is global and constant, so it does not make sense to
validate it during every call to fetch. Instead validate it once, during
adapter read construction.