### PR TITLE
read.js - handle 'raw' option in querybuilder

### DIFF
--- a/lib/query/select.js
+++ b/lib/query/select.js
@@ -28,6 +28,9 @@ SelectBuilder.prototype.build = function(options, filter_opts) {
     options = options || {};
     filter_opts = filter_opts || {};
 
+    // Raw query, nothing to do
+    if (options.raw) { return options.raw; }
+
     if (!options.nameField) { throw new Error('Missing required option: nameField'); }
 
     var root  = filter_opts.filter_ast;

--- a/lib/read.js
+++ b/lib/read.js
@@ -36,15 +36,13 @@ var Read = Juttle.proc.source.extend({
 
         this.queryBuilder = new QueryBuilder();
         this.queryOptions = _.defaults(
-            _.pick(options, 'offset', 'limit', 'fields', 'from', 'to'),
+            _.pick(options, 'offset', 'limit', 'fields', 'from', 'to', 'raw'),
             {
                 nameField: this.nameField,
                 limit: 1000,
             }
         );
         this.queryFilter  = params;
-
-        this.raw = options.raw;
     },
 
     setUrl: function(urlStr) {
@@ -128,7 +126,7 @@ var Read = Juttle.proc.source.extend({
         var parsedUrl = _.clone(this.url);
         var reqUrl = null;
 
-        var query = this.raw ? this.raw : this.queryBuilder.build(this.queryOptions, this.queryFilter);
+        var query = this.queryBuilder.build(this.queryOptions, this.queryFilter);
 
         _.extend(parsedUrl, { pathname: '/query', query: { 'q': query, 'db': this.db, 'epoch' : 'ms' } });
 

--- a/test/influx-live.spec.js
+++ b/test/influx-live.spec.js
@@ -114,6 +114,7 @@ describe('@live influxdb tests', function () {
             return check_juttle({
                 program: 'read influx -db "test" -raw "SELECT * FROM cpu" | view logger'
             }).then(function(res) {
+                expect(res.errors.length).to.equal(0);
                 expect(res.sinks.logger.length).to.equal(10);
                 expect(res.sinks.logger[0].value).to.equal(0);
             });


### PR DESCRIPTION
Instead of handling 'raw' option (containing a query string) in read,
pass that option along to query builder and let it decide what to do -
in this case, just return the query string back.