### PR TITLE
Time range semantics

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -24,8 +24,21 @@ var Read = Juttle.proc.source.extend({
             throw new Error('Unknown option ' + unknown[0]);
         }
 
-        if (options.from && options.to && JuttleMoment.gt(options.from, options.to)) {
-            throw new Error('From cannot be after to');
+        if (options.raw) {
+            if (options.from || options.to) {
+                throw new Error('-raw option should not be combined with -from, -to, or -last');
+            }
+        } else {
+            if (!options.from && !options.to) {
+                throw new Error('One of -from, -to, or -last must be specified to define a query time range');
+            }
+
+            options.from = options.from || program.now;
+            options.to = options.to || program.now;
+
+            if (JuttleMoment.gt(options.from, options.to)) {
+                throw new Error('From cannot be after to');
+            }
         }
 
         this.nameField = options.nameField || 'name';

--- a/lib/read.js
+++ b/lib/read.js
@@ -16,7 +16,7 @@ request.async = Promise.promisify(request);
 var Read = Juttle.proc.source.extend({
     procName: 'read-influx',
 
-    initialize: function(options, params, pname, location, program, juttle) {
+    initialize: function(options, params, location, program) {
         var allowed_options = ['raw', 'db', 'offset', 'limit', 'fields', 'nameField', 'from', 'to'];
         var unknown = _.difference(_.keys(options), allowed_options);
 


### PR DESCRIPTION
Implement validation of time options according to the spec for big-data
adapters published here:

https://github.com/juttle/juttle/wiki/Time-Range-Semantics

For now, do not handle -last option and use native JS errors until
we decide on how to handle errors in adapters.