### PR TITLE
time-filter.js - fix time handling w/o where

### DIFF
--- a/lib/query/select.js
+++ b/lib/query/select.js
@@ -59,7 +59,7 @@ SelectBuilder.prototype._select = function(options, filter_opts) {
 
 SelectBuilder.prototype._where = function(options, filter_opts) {
     var root  = filter_opts.filter_ast;
-    var where = "";
+    var where = '';
 
     if (root) {
         // Rewrite juttle expressions not understood by influx
@@ -72,7 +72,7 @@ SelectBuilder.prototype._where = function(options, filter_opts) {
     // FIXME: It'd be nicer (but more complex) to handle this on an AST level
     where = this.timeFilter.addFilter(where, options.from, options.to);
 
-    if (typeof where === 'undefined' || where === "") {
+    if (where === '') {
         return null;
     } else {
         return ['WHERE', where].join(' ');

--- a/lib/query/time-filter.js
+++ b/lib/query/time-filter.js
@@ -7,7 +7,7 @@
 var TimeFilter = function() {};
 
 TimeFilter.prototype.addFilter = function(where, from, to) {
-    if (typeof where !== 'undefined' && where !== '' && (from || to)) {
+    if (where !== '' && (from || to)) {
         where += ' AND ';
     }
 

--- a/lib/query/where.js
+++ b/lib/query/where.js
@@ -23,11 +23,17 @@ var WhereBuilder = ASTVisitor.extend({
     },
 
     build: function(ast, options) {
-        var op;
+        var op, where;
 
         if (!options.nameField) { throw new Error('Missing required option: nameField'); }
 
-        return this.visit(ast, op, options);
+        where = this.visit(ast, op, options);
+
+        if (typeof where === 'undefined') {
+            return '';
+        } else {
+            return String(where);
+        }
     },
 
     visitSimpleFilterTerm: function(node, op, options) {

--- a/test/query/query.spec.js
+++ b/test/query/query.spec.js
@@ -233,6 +233,11 @@ describe('influxql query building', function() {
                     expect(builder.build({ from: from, to: to, nameField: 'name' }, { filter_ast: ast })).to.equal('SELECT * FROM /.*/ WHERE "key" != 1 AND "time" >= \'' + from.valueOf() + '\' AND "time" < \'' + to.valueOf() + '\'');
                 });
 
+                it('with name field', function() {
+                    var ast = utils.parseFilter('name = "cpu"');
+                    expect(builder.build({ from: from, to: to, nameField: 'name' }, { filter_ast: ast })).to.equal('SELECT * FROM "cpu" WHERE "time" >= \'' + from.valueOf() + '\' AND "time" < \'' + to.valueOf() + '\'');
+                });
+
                 it('only from', function() {
                     expect(builder.build({ from: from, nameField: 'name' })).to.equal('SELECT * FROM /.*/ WHERE "time" >= \'' + from.valueOf() + '\'');
                 });


### PR DESCRIPTION
Fix edge case triggered when 'nameField' gets filtered out from the
filter AST, where clause is thus equal to undefined and from / to is
specified.

Time-filter was not be able to cope with undefineds - it stringified it,
instead of starting with an empty string.