### PR TITLE
Adapter api

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,8 @@
     "env": {
         "browser": true,
         "node": true,
-        "mocha": true
+        "mocha": true,
+        "es6": true
     },
     "rules": {
         "indent": [ 2, 4, { "SwitchCase": 1 } ],

--- a/lib/ast/lint.js
+++ b/lib/ast/lint.js
@@ -1,11 +1,10 @@
 'use strict';
 
 var ASTVisitor = require('juttle/lib/compiler/ast-visitor');
-var _ = require('underscore');
 var ast_utils = require('./utils');
 
-var Lints = {
-    lint: function(ast, o) {
+class Linter extends ASTVisitor {
+    lint(ast, o) {
         if (!o.nameField) { throw new Error('Missing required option: nameField'); }
 
         var options = {
@@ -19,9 +18,9 @@ var Lints = {
         if (options.nameFilters > 1) {
             throw new Error('Name field ' + options.nameField + ' can be present at most once');
         }
-    },
+    }
 
-    visitBinaryExpression: function(node, options) {
+    visitBinaryExpression(node, options) {
         if (ast_utils.isNameField(node.left, options.nameField)) {
             if (node.operator !== '==' && node.operator !== '=~') {
                 throw new Error('Only equality and regular expressions are supported for nameField');
@@ -44,9 +43,9 @@ var Lints = {
         this.visit(node.right, options);
 
         options.disallowNameField = false;
-    },
+    }
 
-    visitUnaryExpression: function(node, options) {
+    visitUnaryExpression(node, options) {
         // No time on LHS.
         if (ast_utils.isTime(node)) {
             throw new Error('Time field is not allowed in filter expressions, use -from and/or -to');
@@ -60,21 +59,22 @@ var Lints = {
         options.disallowNameField = true;
         this.visit(node.expression, options);
         options.disallowNameField = false;
-    },
+    }
 
-    visit: function(node, options) {
+    visit(node, options) {
         if (ast_utils.isNameField(node, options.nameField) && options.disallowNameField) {
             throw new Error(options.nameField + ' cannot be nested inside the filter.');
         }
         this['visit' + node.type].apply(this, arguments);
     }
-};
 
-// Duration comparisons are not supported (they could be converted to moments, though)
-_.each(['MomentLiteral', 'DurationLiteral'], function(node_name) {
-    Lints['visit' + node_name] = function(node, options) {
+    visitMomentLiteral(node, options) {
         throw new Error('Filtering by time is not supported');
-    };
-});
+    }
 
-module.exports = ASTVisitor.extend(Lints);
+    visitDurationLiteral(node, options) {
+        throw new Error('Filtering by time is not supported');
+    }
+}
+
+module.exports = Linter;

--- a/lib/ast/rewrite.js
+++ b/lib/ast/rewrite.js
@@ -15,25 +15,27 @@
 var InRewriter = require('./rewrite/in');
 var NotRewriter = require('./rewrite/not');
 
-var Rewriter = function(ast) {
-    this.notRewriter = new NotRewriter();
-    this.inRewriter  = new InRewriter();
-};
+class Rewriter {
+    constructor(ast) {
+        this.notRewriter = new NotRewriter();
+        this.inRewriter  = new InRewriter();
+    }
 
-Rewriter.prototype.rewrite = function(_ast) {
-    // This is a hack to workaround the fact that top level node in the filter
-    // is FilterExpressionTerm. If we need to rewrite it in JS, we're out of luck
-    // without a proper ASTrewriter that knows about AST nodes & their properties.
-    // A neat TODO.
-    var ast = { type: "FilterLiteral", ast: JSON.parse(JSON.stringify(_ast)) };
+    rewrite(_ast) {
+        // This is a hack to workaround the fact that top level node in the filter
+        // is FilterExpressionTerm. If we need to rewrite it in JS, we're out of luck
+        // without a proper ASTrewriter that knows about AST nodes & their properties.
+        // A neat TODO.
+        var ast = { type: "FilterLiteral", ast: JSON.parse(JSON.stringify(_ast)) };
 
-    // Order matters here. The second rewrite assumes there is no 'in'
-    // operator left in the tree, as there is no operator corresponding
-    // to 'not in'.
-    this.inRewriter.visit(ast);
-    this.notRewriter.visit(ast);
+        // Order matters here. The second rewrite assumes there is no 'in'
+        // operator left in the tree, as there is no operator corresponding
+        // to 'not in'.
+        this.inRewriter.visit(ast);
+        this.notRewriter.visit(ast);
 
-    return ast.ast;
-};
+        return ast.ast;
+    }
+}
 
 module.exports = Rewriter;

--- a/lib/ast/rewrite/in.js
+++ b/lib/ast/rewrite/in.js
@@ -8,14 +8,14 @@
 var ASTVisitor = require('juttle/lib/compiler/ast-visitor');
 var _ = require('underscore');
 
-var Rewriter = ASTVisitor.extend({
-    _hasIn: function(node) {
+class Rewriter extends ASTVisitor {
+    _hasIn(node) {
         return (node.type === 'ExpressionFilterTerm' &&
                 node.expression.type === 'BinaryExpression' &&
                 node.expression.operator === 'in');
-    },
+    }
 
-    _rewriteIn: function(_node) {
+    _rewriteIn(_node) {
         var elements = _node.expression.right.elements;
 
         var equalities = _.map(elements, function(elm) {
@@ -49,29 +49,29 @@ var Rewriter = ASTVisitor.extend({
             }, equalities.shift());
             return ors;
         }
-    },
+    }
 
-    visitFilterLiteral: function(node) {
+    visitFilterLiteral(node) {
         if (this._hasIn(node.ast)) { node.ast = this._rewriteIn(node.ast); }
         this.visit(node.ast);
-    },
+    }
 
-    visitUnaryExpression: function(node) {
+    visitUnaryExpression(node) {
         if (this._hasIn(node.expression)) { node.expression = this._rewriteIn(node.expression); }
         this.visit(node.expression);
-    },
+    }
 
-    visitBinaryExpression: function(node) {
+    visitBinaryExpression(node) {
         if (this._hasIn(node.right)) { node.right = this._rewriteIn(node.right); }
         if (this._hasIn(node.left)) { node.left = this._rewriteIn(node.left); }
 
         this.visit(node.left);
         this.visit(node.right);
-    },
+    }
 
-    visit: function(node) {
+    visit(node) {
         this['visit' + node.type].apply(this, arguments);
     }
-});
+}
 
 module.exports = Rewriter;

--- a/lib/ast/rewrite/not.js
+++ b/lib/ast/rewrite/not.js
@@ -6,8 +6,8 @@
 
 var ASTVisitor = require('juttle/lib/compiler/ast-visitor');
 
-var Rewriter = ASTVisitor.extend({
-    negate: function(op) {
+class Rewriter extends ASTVisitor {
+    negate(op) {
         // Missing in this list is 'in'. It is missing an opposite operator,
         // and also not supported in InfluxDB. We assume it was transformed
         // into ORs sequence in a previous rewrite.
@@ -24,9 +24,9 @@ var Rewriter = ASTVisitor.extend({
             'OR':  'AND'
         };
         return negations[op];
-    },
+    }
 
-    visitBinaryExpression: function(node, negate) {
+    visitBinaryExpression(node, negate) {
         if (this._hasNegation(node.left)) {
             this.visit(node.left, !negate);
             node.left = this._rewriteNegation(node.left);
@@ -48,46 +48,46 @@ var Rewriter = ASTVisitor.extend({
 
             node.operator = op;
         }
-    },
+    }
 
-    visitUnaryExpression: function(node, negate) {
+    visitUnaryExpression(node, negate) {
         if (this._hasNegation(node.expression)) {
             this.visit(node.expression, !negate);
             node.expression = this._rewriteNegation(node.expression);
         } else {
             this.visit(node.expression, negate);
         }
-    },
+    }
 
-    _hasNegation: function(node) {
+    _hasNegation(node) {
         return (node.type === 'UnaryExpression' && node.operator === 'NOT');
-    },
+    }
 
-    _rewriteNegation: function(node) {
+    _rewriteNegation(node) {
         return node.expression;
-    },
+    }
 
-    visitExpressionFilterTerm: function(node, negate) {
+    visitExpressionFilterTerm(node, negate) {
         if (this._hasNegation(node.expression)) {
             this.visit(node.expression, !negate);
             node.expression = this._rewriteNegation(node.expression);
         } else {
             this.visit(node.expression, negate);
         }
-    },
+    }
 
-    visitFilterLiteral: function(node, negate) {
+    visitFilterLiteral(node, negate) {
         if (this._hasNegation(node.ast)) {
             this.visit(node.ast, !negate);
             node.ast = this._rewriteNegation(node.ast);
         } else {
             this.visit(node.ast, negate);
         }
-    },
+    }
 
-    visit: function(node, negate) {
+    visit(node, negate) {
         this['visit' + node.type].apply(this, arguments);
     }
-});
+}
 
 module.exports = Rewriter;

--- a/lib/query/from.js
+++ b/lib/query/from.js
@@ -1,13 +1,15 @@
+'use strict';
+
 var ASTVisitor = require('juttle/lib/compiler/ast-visitor');
 var g2r = require('glob-to-regexp');
 var ast_utils = require('../ast/utils');
 
-var FromBuilder = ASTVisitor.extend({
-    build: function(ast, options) {
+class FromBuilder extends ASTVisitor {
+    build(ast, options) {
         return this.visit(ast, options);
-    },
+    }
 
-    visitBinaryExpression: function(node, options) {
+    visitBinaryExpression(node, options) {
         if (ast_utils.isNameField(node.left, options.nameField)) {
             if (node.operator === '=~') {
                 if (node.right.type === 'StringLiteral') {
@@ -22,23 +24,23 @@ var FromBuilder = ASTVisitor.extend({
         var left  = this.visit(node.left, options);
         var right = this.visit(node.right, options);
         return left || right;
-    },
+    }
 
-    visitFilterLiteral: function(node, options) {
+    visitFilterLiteral(node, options) {
         return this.visit(node.ast, options);
-    },
+    }
 
-    visitSimpleFilterTerm: function(node, options) {
+    visitSimpleFilterTerm(node, options) {
         return this.visit(node.expression, options);
-    },
+    }
 
-    visitExpressionFilterTerm: function(node, options) {
+    visitExpressionFilterTerm(node, options) {
         return this.visit(node.expression, options);
-    },
+    }
 
-    visit: function(node, options) {
+    visit(node, options) {
         return this['visit' + node.type].apply(this, arguments);
     }
-});
+}
 
 module.exports = FromBuilder;

--- a/lib/query/select.js
+++ b/lib/query/select.js
@@ -10,104 +10,106 @@ var TimeFilter = require('./time-filter');
 /*
  * Compiles juttle options & filter ASTs to influx select queries.
  */
-var SelectBuilder = function() {
-    this.rewriter = new Rewriter();
-    this.whereBuilder = new WhereBuilder();
-    this.fromBuilder = new FromBuilder();
-    this.linter = new Linter();
-    this.timeFilter = new TimeFilter();
-};
-
-/*
- * select_stmt = "SELECT" fields from_clause [ into_clause *] [ where_clause ]
- *               [ group_by_clause *] [ order_by_clause ] [ limit_clause ]
- *               [ offset_clause *] [ slimit_clause *] [ soffset_clause *]
- * Constructs marked with * are not supported.
- */
-SelectBuilder.prototype.build = function(options, filter_opts) {
-    options = options || {};
-    filter_opts = filter_opts || {};
-
-    // Raw query, nothing to do
-    if (options.raw) { return options.raw; }
-
-    if (!options.nameField) { throw new Error('Missing required option: nameField'); }
-
-    var root  = filter_opts.filter_ast;
-
-    if (root) {
-        this.linter.lint(root, _.pick(options, 'nameField'));
+class SelectBuilder {
+    constructor() {
+        this.rewriter = new Rewriter();
+        this.whereBuilder = new WhereBuilder();
+        this.fromBuilder = new FromBuilder();
+        this.linter = new Linter();
+        this.timeFilter = new TimeFilter();
     }
 
-    return _.compact([
-        this._select(options, filter_opts),
-        this._from(options, filter_opts),
-        this._where(options, filter_opts),
-        this._orderBy(options, filter_opts),
-        this._limit(options, filter_opts),
-        this._offset(options, filter_opts)
-    ]).join(' ');
-};
+    /*
+     * select_stmt = "SELECT" fields from_clause [ into_clause *] [ where_clause ]
+     *               [ group_by_clause *] [ order_by_clause ] [ limit_clause ]
+     *               [ offset_clause *] [ slimit_clause *] [ soffset_clause *]
+     * Constructs marked with * are not supported.
+     */
+    build(options, filter_opts) {
+        options = options || {};
+        filter_opts = filter_opts || {};
 
-SelectBuilder.prototype._select = function(options, filter_opts) {
-    var fields = options.fields || '*';
+        // Raw query, nothing to do
+        if (options.raw) { return options.raw; }
 
-    if (_.isArray(fields)) { fields = fields.join(','); }
+        if (!options.nameField) { throw new Error('Missing required option: nameField'); }
 
-    return ['SELECT', fields].join(' ');
-};
+        var root  = filter_opts.filter_ast;
 
-SelectBuilder.prototype._where = function(options, filter_opts) {
-    var root  = filter_opts.filter_ast;
-    var where = '';
+        if (root) {
+            this.linter.lint(root, _.pick(options, 'nameField'));
+        }
 
-    if (root) {
-        // Rewrite juttle expressions not understood by influx
-        root = this.rewriter.rewrite(root);
-
-        // Get query filter
-        where = this.whereBuilder.build(root, _.pick(options, 'nameField'));
+        return _.compact([
+            this._select(options, filter_opts),
+            this._from(options, filter_opts),
+            this._where(options, filter_opts),
+            this._orderBy(options, filter_opts),
+            this._limit(options, filter_opts),
+            this._offset(options, filter_opts)
+        ]).join(' ');
     }
 
-    // FIXME: It'd be nicer (but more complex) to handle this on an AST level
-    where = this.timeFilter.addFilter(where, options.from, options.to);
+    _select(options, filter_opts) {
+        var fields = options.fields || '*';
 
-    if (where === '') {
-        return null;
-    } else {
-        return ['WHERE', where].join(' ');
-    }
-};
+        if (_.isArray(fields)) { fields = fields.join(','); }
 
-SelectBuilder.prototype._from = function(options, filter_opts) {
-    var root = filter_opts.filter_ast;
-    var from = "";
-
-    if (root) {
-        from = this.fromBuilder.build(root, _.pick(options, 'nameField'));
+        return ['SELECT', fields].join(' ');
     }
 
-    return ['FROM', from || '/.*/'].join(' ');
-};
+    _where(options, filter_opts) {
+        var root  = filter_opts.filter_ast;
+        var where = '';
 
-SelectBuilder.prototype._limit = function(options, filter_ast) {
-    if (options.limit) {
-        return ['LIMIT', options.limit].join(' ');
-    } else {
-        return null;
+        if (root) {
+            // Rewrite juttle expressions not understood by influx
+            root = this.rewriter.rewrite(root);
+
+            // Get query filter
+            where = this.whereBuilder.build(root, _.pick(options, 'nameField'));
+        }
+
+        // FIXME: It'd be nicer (but more complex) to handle this on an AST level
+        where = this.timeFilter.addFilter(where, options.from, options.to);
+
+        if (where === '') {
+            return null;
+        } else {
+            return ['WHERE', where].join(' ');
+        }
     }
-};
 
-SelectBuilder.prototype._offset = function(options, filter_ast) {
-    if (options.offset) {
-        return ['OFFSET', options.offset].join(' ');
-    } else {
-        return null;
+    _from(options, filter_opts) {
+        var root = filter_opts.filter_ast;
+        var from = "";
+
+        if (root) {
+            from = this.fromBuilder.build(root, _.pick(options, 'nameField'));
+        }
+
+        return ['FROM', from || '/.*/'].join(' ');
     }
-};
 
-SelectBuilder.prototype._orderBy = function(options, filter_ast) {
-    // FIXME
-};
+    _limit(options, filter_ast) {
+        if (options.limit) {
+            return ['LIMIT', options.limit].join(' ');
+        } else {
+            return null;
+        }
+    }
+
+    _offset(options, filter_ast) {
+        if (options.offset) {
+            return ['OFFSET', options.offset].join(' ');
+        } else {
+            return null;
+        }
+    }
+
+    _orderBy(options, filter_ast) {
+        // FIXME
+    }
+}
 
 module.exports = SelectBuilder;

--- a/lib/query/time-filter.js
+++ b/lib/query/time-filter.js
@@ -4,26 +4,26 @@
  * Adds 'from' and 'to' limits to the query.
  */
 
-var TimeFilter = function() {};
+class TimeFilter {
+    addFilter(where, from, to) {
+        if (where !== '' && (from || to)) {
+            where += ' AND ';
+        }
 
-TimeFilter.prototype.addFilter = function(where, from, to) {
-    if (where !== '' && (from || to)) {
-        where += ' AND ';
+        if (from) {
+            where += '"time" >= \'' + from.valueOf() + '\'';
+        }
+
+        if (from && to) {
+            where += ' AND ';
+        }
+
+        if (to) {
+            where += '"time" < \'' + to.valueOf() + '\'';
+        }
+
+        return where;
     }
-
-    if (from) {
-        where += '"time" >= \'' + from.valueOf() + '\'';
-    }
-
-    if (from && to) {
-        where += ' AND ';
-    }
-
-    if (to) {
-        where += '"time" < \'' + to.valueOf() + '\'';
-    }
-
-    return where;
-};
+}
 
 module.exports = TimeFilter;

--- a/lib/query/where.js
+++ b/lib/query/where.js
@@ -4,8 +4,10 @@ var ASTVisitor = require('juttle/lib/compiler/ast-visitor');
 var g2r = require('glob-to-regexp');
 var ast_utils = require('../ast/utils');
 
-var WhereBuilder = ASTVisitor.extend({
-    initialize: function() {
+class WhereBuilder extends ASTVisitor {
+    constructor() {
+        super();
+
         this.ops = {
             '==': '=',
             'AND': 'AND',
@@ -20,9 +22,9 @@ var WhereBuilder = ASTVisitor.extend({
             //'NOT': undefined,
             //'IN': undefined,
         };
-    },
+    }
 
-    build: function(ast, options) {
+    build(ast, options) {
         var op, where;
 
         if (!options.nameField) { throw new Error('Missing required option: nameField'); }
@@ -34,49 +36,49 @@ var WhereBuilder = ASTVisitor.extend({
         } else {
             return String(where);
         }
-    },
+    }
 
-    visitSimpleFilterTerm: function(node, op, options) {
+    visitSimpleFilterTerm(node, op, options) {
         return this.visit(node.expression, op, options);
-    },
+    }
 
-    visitBooleanLiteral: function(node, op, options) {
+    visitBooleanLiteral(node, op, options) {
         return node.value;
-    },
+    }
 
-    visitFilterLiteral: function(node, op, options) {
+    visitFilterLiteral(node, op, options) {
         return this.visit(node.ast, op, options);
-    },
+    }
 
-    visitExpressionFilterTerm: function(node, op, options) {
+    visitExpressionFilterTerm(node, op, options) {
         return this.visit(node.expression, op, options);
-    },
+    }
 
-    visitRegularExpressionLiteral: function(node, op, options) {
+    visitRegularExpressionLiteral(node, op, options) {
         return '/' + node.value + '/';
-    },
+    }
 
-    visitStringLiteral: function(node, op, options) {
+    visitStringLiteral(node, op, options) {
         if (op && (op === '!~' || op === '=~')) {
             return String(g2r(node.value));
         } else {
             return '\'' + node.value + '\'';
         }
-    },
+    }
 
-    visitNumericLiteral: function(node, op, options) {
+    visitNumericLiteral(node, op, options) {
         return node.value;
-    },
+    }
 
-    visitNullLiteral: function(node, op, options) {
+    visitNullLiteral(node, op, options) {
         return 'null';
-    },
+    }
 
-    visitVariable: function(node, op, options) {
+    visitVariable(node, op, options) {
         return '"' + node.name + '"';
-    },
+    }
 
-    visitUnaryExpression: function(node, op, options) {
+    visitUnaryExpression(node, op, options) {
         // Field dereference
         if (node.operator === '*') {
             return '"' + node.expression.value + '"';
@@ -87,9 +89,9 @@ var WhereBuilder = ASTVisitor.extend({
 
             return '( ' + operator + ' ' + this.visit(node.expression, operator, options) + ' )';
         }
-    },
+    }
 
-    visitBinaryExpression: function(node, op, options) {
+    visitBinaryExpression(node, op, options) {
         var operator = this.ops[node.operator];
 
         if (!operator) { throw new Error('Operator ' + node.operator + ' not supported by InfluxQL'); }
@@ -115,11 +117,11 @@ var WhereBuilder = ASTVisitor.extend({
         }
 
         return str;
-    },
+    }
 
-    visit: function(node, op, options) {
+    visit(node, op, options) {
         return this['visit' + node.type].apply(this, arguments);
     }
-});
+}
 
 module.exports = WhereBuilder;

--- a/lib/read.js
+++ b/lib/read.js
@@ -13,7 +13,7 @@ var QueryBuilder = require('./query');
 var request = Promise.promisifyAll(require('request'));
 request.async = Promise.promisify(request);
 
-class Read extends AdapterRead {
+class ReadInflux extends AdapterRead {
     constructor(options, params) {
         super(options, params);
 
@@ -163,4 +163,4 @@ class Read extends AdapterRead {
     }
 }
 
-module.exports = Read;
+module.exports = ReadInflux;

--- a/lib/read.js
+++ b/lib/read.js
@@ -4,7 +4,7 @@ var _ = require('underscore');
 var url = require('url');
 var Promise = require('bluebird');
 var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
-var Juttle = require('juttle/lib/runtime').Juttle;
+var AdapterRead = require('juttle/lib/runtime/adapter-read');
 
 var Config = require('./config');
 var Serializer = require('./serializer');
@@ -13,11 +13,13 @@ var QueryBuilder = require('./query');
 var request = Promise.promisifyAll(require('request'));
 request.async = Promise.promisify(request);
 
-var Read = Juttle.proc.source.extend({
-    procName: 'read-influx',
+class Read extends AdapterRead {
+    constructor(options, params) {
+        super(options, params);
 
-    initialize: function(options, params, location, program) {
-        var allowed_options = ['raw', 'db', 'offset', 'limit', 'fields', 'nameField', 'from', 'to'];
+        var allowed_options = AdapterRead.commonOptions.concat([
+            'raw', 'db', 'offset', 'limit', 'fields', 'nameField'
+        ]);
         var unknown = _.difference(_.keys(options), allowed_options);
 
         if (unknown.length > 0) {
@@ -25,20 +27,19 @@ var Read = Juttle.proc.source.extend({
         }
 
         if (options.raw) {
-            if (options.from || options.to) {
+            if (this.options.from || this.options.to) {
                 throw new Error('-raw option should not be combined with -from, -to, or -last');
             }
+
+            this.from = undefined;
+            this.to = undefined;
         } else {
-            if (!options.from && !options.to) {
+            if (!this.options.from && !this.options.to) {
                 throw new Error('One of -from, -to, or -last must be specified to define a query time range');
             }
 
-            options.from = options.from || program.now;
-            options.to = options.to || program.now;
-
-            if (JuttleMoment.gt(options.from, options.to)) {
-                throw new Error('From cannot be after to');
-            }
+            this.from = this.options.from || params.now;
+            this.to = this.options.to || params.now;
         }
 
         this.nameField = options.nameField || 'name';
@@ -49,16 +50,16 @@ var Read = Juttle.proc.source.extend({
 
         this.queryBuilder = new QueryBuilder();
         this.queryOptions = _.defaults(
-            _.pick(options, 'offset', 'limit', 'fields', 'from', 'to', 'raw'),
+            _.pick(options, 'offset', 'limit', 'fields', 'raw'),
             {
                 nameField: this.nameField,
                 limit: 1000,
             }
         );
         this.queryFilter  = params;
-    },
+    }
 
-    setUrl: function(urlStr) {
+    setUrl(urlStr) {
         var urlObj = {};
 
         try {
@@ -72,22 +73,9 @@ var Read = Juttle.proc.source.extend({
         }
 
         return urlObj;
-    },
+    }
 
-    start: function() {
-        var self = this;
-
-        return this.fetch()
-        .then(function(data) {
-            self.emit(self.parse(data));
-            self.emit_eof();
-        }).catch(function(err) {
-            self.trigger('error', err);
-            self.emit_eof();
-        });
-    },
-
-    toNative: function(s) {
+    toNative(s) {
         var self = this;
         if (_.contains(s.columns, this.nameField)) {
             self.trigger('warning',
@@ -100,9 +88,9 @@ var Read = Juttle.proc.source.extend({
         return _.map(s.values, function(row) {
             return self.serializer.toJuttle(s.name, s.columns, row, self.nameField);
         });
-    },
+    }
 
-    _sort: function(t1, t2) {
+    _sort(t1, t2) {
         if (!_.has(t1, 'time') && !_.has(t2, 'time')) {
             return 0;
         }
@@ -113,9 +101,9 @@ var Read = Juttle.proc.source.extend({
             return 1;
         }
         return JuttleMoment.compare(t1.time, t2.time);
-    },
+    }
 
-    parse: function(data) {
+    parse(data) {
         var e  = _.find(data.results, 'error');
 
         if (e && e.error) {
@@ -133,13 +121,27 @@ var Read = Juttle.proc.source.extend({
                 .sort(this._sort)
                 .value();
         }
-    },
+    }
 
-    fetch: function() {
+    defaultTimeRange() {
+        return {
+            from: this.from,
+            to: this.to
+        };
+    }
+
+    periodicLiveRead() {
+        return this.queryOptions.raw === undefined;
+    }
+
+    read(from, to, limit, state) {
+        var self = this;
+
         var parsedUrl = _.clone(this.url);
         var reqUrl = null;
 
-        var query = this.queryBuilder.build(this.queryOptions, this.queryFilter);
+        var queryOptions = _.extend({ to: to, from: from }, this.queryOptions);
+        var query = this.queryBuilder.build(queryOptions, this.queryFilter);
 
         _.extend(parsedUrl, { pathname: '/query', query: { 'q': query, 'db': this.db, 'epoch' : 'ms' } });
 
@@ -150,11 +152,15 @@ var Read = Juttle.proc.source.extend({
             if (response.statusCode < 200 || response.statusCode >= 300) {
                 throw new Error(response.statusCode + ': ' + response.body + ' for ' + reqUrl);
             }
-            return JSON.parse(response.body);
+
+            return {
+                points: self.parse(JSON.parse(response.body)),
+                readEnd: to || new JuttleMoment(Infinity)
+            };
         }).catch(function(e) {
             throw e;
         });
-    },
-});
+    }
+}
 
 module.exports = Read;

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -8,97 +8,99 @@ var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
 var values = require('juttle/lib/runtime/values');
 var _ = require('underscore');
 
-var Serializer = function(options) {
-    this.options = options || {};
+class Serializer {
+    constructor(options) {
+        this.options = options || {};
 
-    this.intFields = this.options.intFields ? this.options.intFields.split(',') : [];
-    this.valFields = this.options.valFields ? this.options.valFields.split(',') : [];
-};
-
-Serializer.prototype.toJuttle = function(name, keys, values, nameField) {
-    if (!name) { throw new Error('name argument required'); }
-    if (!keys) { throw new Error('keys argument required'); }
-    if (!values) { throw new Error('values argument required'); }
-    if (!nameField) { throw new Error('nameField argument required'); }
-
-    // FIXME: our sinks can't handle nulls?
-    var obj  = _.object(keys, _.map(values, function(v) { return (v === null ? '' : v); }));
-
-    obj[nameField] = name;
-
-    if (obj.time) {
-        obj.time = JuttleMoment.parse(obj.time);
+        this.intFields = this.options.intFields ? this.options.intFields.split(',') : [];
+        this.valFields = this.options.valFields ? this.options.valFields.split(',') : [];
     }
 
-    return obj;
-};
+    toJuttle(name, keys, values, nameField) {
+        if (!name) { throw new Error('name argument required'); }
+        if (!keys) { throw new Error('keys argument required'); }
+        if (!values) { throw new Error('values argument required'); }
+        if (!nameField) { throw new Error('nameField argument required'); }
 
-Serializer.prototype.toInflux = function(point, nameField) {
-    if (!nameField) { throw new Error('nameField argument required'); }
+        // FIXME: our sinks can't handle nulls?
+        var obj  = _.object(keys, _.map(values, function(v) { return (v === null ? '' : v); }));
 
-    var name = point[nameField];
-    var timestamp_ns = point.time ? point.time.unixms() : null;
+        obj[nameField] = name;
 
-    point = _.omit(point, nameField, 'time');
+        if (obj.time) {
+            obj.time = JuttleMoment.parse(obj.time);
+        }
 
-    var tags = _.pick(point, this._isTag.bind(this));
-    var vals = _.omit(point, this._isTag.bind(this));
-
-    if (_.keys(vals).length === 0) { throw new Error('point requires at least one field'); }
-    if (!name) { throw new Error('point is missing a name'); }
-
-    var key = _.flatten([name, _.map(tags, this._concatKeyVal)]).map(this._escapeTag);
-
-    var val = _.chain(vals)
-               .map(this._serializeValue.bind(this))
-               .object()
-               .map(this._concatKeyVal)
-               .value();
-
-    return _.compact([key.join(","), val.join(","), timestamp_ns]).join(" ");
-};
-
-Serializer.prototype._concatKeyVal = function(v, k) {
-    return k + '=' + v;
-};
-
-Serializer.prototype._serializeValue = function(v, k) {
-    if (values.isBoolean(v)) {
-        return [k, (v ? 't' : 'f')];
-    } else
-    if (values.isString(v)) {
-        return [k, '"' + this._escapeString(v) + '"'];
-    } else
-    if (this._isInt(v, k)) {
-        return [k, Math.floor(v) + 'i'];
-    } else
-    if (values.isDate(v) || values.isDuration(v)) {
-        return [k, v.unixms()];
-    } else
-    if (values.isObject(v) || values.isArray(v)) {
-        throw new Error('Serializing array and object fields is not supported.');
-    } else {
-        return [k, v];
+        return obj;
     }
-};
 
-// https://influxdb.com/docs/v0.9/write_protocols/line.html#key
-Serializer.prototype._escapeTag = function(str) {
-    var specialChars = /[\s,]/g;
-    return str.replace(specialChars, function(m) { return "\\" + m; });
-};
+    toInflux(point, nameField) {
+        if (!nameField) { throw new Error('nameField argument required'); }
 
-// https://influxdb.com/docs/v0.9/write_protocols/line.html#fields (Strings)
-Serializer.prototype._escapeString = function(str) {
-    return str.replace(/"/g, '\\"');
-};
+        var name = point[nameField];
+        var timestamp_ns = point.time ? point.time.unixms() : null;
 
-Serializer.prototype._isTag = function(val, key, obj) {
-    return _.isString(val) && !_.contains(this.valFields, key);
-};
+        point = _.omit(point, nameField, 'time');
 
-Serializer.prototype._isInt = function(val, key, obj) {
-    return _.isNumber(val) && _.contains(this.intFields, key);
-};
+        var tags = _.pick(point, this._isTag.bind(this));
+        var vals = _.omit(point, this._isTag.bind(this));
+
+        if (_.keys(vals).length === 0) { throw new Error('point requires at least one field'); }
+        if (!name) { throw new Error('point is missing a name'); }
+
+        var key = _.flatten([name, _.map(tags, this._concatKeyVal)]).map(this._escapeTag);
+
+        var val = _.chain(vals)
+                   .map(this._serializeValue.bind(this))
+                   .object()
+                   .map(this._concatKeyVal)
+                   .value();
+
+        return _.compact([key.join(","), val.join(","), timestamp_ns]).join(" ");
+    }
+
+    _concatKeyVal(v, k) {
+        return k + '=' + v;
+    }
+
+    _serializeValue(v, k) {
+        if (values.isBoolean(v)) {
+            return [k, (v ? 't' : 'f')];
+        } else
+        if (values.isString(v)) {
+            return [k, '"' + this._escapeString(v) + '"'];
+        } else
+        if (this._isInt(v, k)) {
+            return [k, Math.floor(v) + 'i'];
+        } else
+        if (values.isDate(v) || values.isDuration(v)) {
+            return [k, v.unixms()];
+        } else
+        if (values.isObject(v) || values.isArray(v)) {
+            throw new Error('Serializing array and object fields is not supported.');
+        } else {
+            return [k, v];
+        }
+    }
+
+    // https://influxdb.com/docs/v0.9/write_protocols/line.html#key
+    _escapeTag(str) {
+        var specialChars = /[\s,]/g;
+        return str.replace(specialChars, function(m) { return "\\" + m; });
+    }
+
+    // https://influxdb.com/docs/v0.9/write_protocols/line.html#fields (Strings)
+    _escapeString(str) {
+        return str.replace(/"/g, '\\"');
+    }
+
+    _isTag(val, key, obj) {
+        return _.isString(val) && !_.contains(this.valFields, key);
+    }
+
+    _isInt(val, key, obj) {
+        return _.isNumber(val) && _.contains(this.intFields, key);
+    }
+}
 
 module.exports = Serializer;

--- a/lib/write.js
+++ b/lib/write.js
@@ -3,7 +3,7 @@
 var _ = require('underscore');
 var url = require('url');
 var Promise = require('bluebird');
-var Juttle = require('juttle/lib/runtime').Juttle;
+var AdapterWrite = require('juttle/lib/runtime/adapter-write');
 
 var Config = require('./config');
 var Serializer = require('./serializer');
@@ -11,10 +11,10 @@ var Serializer = require('./serializer');
 var request = Promise.promisifyAll(require('request'));
 request.async = Promise.promisify(request);
 
-var Write = Juttle.proc.sink.extend({
-    procName: 'write-influx',
+class Write extends AdapterWrite {
+    constructor(options, params) {
+        super(options, params);
 
-    initialize: function(options, params) {
         this.name = 'write-influx';
 
         var allowed_options = ['raw', 'db', 'intFields', 'valFields', 'nameField'];
@@ -29,9 +29,10 @@ var Write = Juttle.proc.sink.extend({
         this.nameField = options.nameField || 'name';
         this.db = options.db || 'test';
         this.url = Config.get().url;
-    },
+        this.pendingWrites = 0;
+    }
 
-    process: function(points) {
+    write(points) {
         var self = this;
 
         var parsedUrl = url.parse(this.url);
@@ -50,6 +51,7 @@ var Write = Juttle.proc.sink.extend({
             }
         })).join("\n");
 
+        this.pendingWrites++;
         return request.async({
             url: reqUrl,
             method: 'POST',
@@ -61,14 +63,31 @@ var Write = Juttle.proc.sink.extend({
                 throw new Error(response.body);
             } else if (response.statusCode > 300) {
                 throw new Error(response.body);
-            } else {
-                self.done();
             }
         }).catch(function(err) {
             self.trigger('error', err);
-            self.done();
+        }).then(function() {
+            self.pendingWrites--;
+            self.checkIfDone();
         });
     }
-});
+
+    eof() {
+        var self = this;
+        if (this.pendingWrites === 0) {
+            return Promise.resolve();
+        } else {
+            return new Promise(function(resolve, reject) {
+                self.onDone = resolve;
+            });
+        }
+    }
+
+    checkIfDone() {
+        if (this.pendingWrites === 0 && this.onDone) {
+            this.onDone();
+        }
+    }
+}
 
 module.exports = Write;

--- a/lib/write.js
+++ b/lib/write.js
@@ -11,7 +11,7 @@ var Serializer = require('./serializer');
 var request = Promise.promisifyAll(require('request'));
 request.async = Promise.promisify(request);
 
-class Write extends AdapterWrite {
+class WriteInflux extends AdapterWrite {
     constructor(options, params) {
         super(options, params);
 
@@ -90,4 +90,4 @@ class Write extends AdapterWrite {
     }
 }
 
-module.exports = Write;
+module.exports = WriteInflux;

--- a/test/influx-live.spec.js
+++ b/test/influx-live.spec.js
@@ -210,7 +210,7 @@ describe('@live influxdb tests', function () {
             return check_juttle({
                 program: 'read influx -db "test" -from :' + from.toISOString() + ': -to :' + to.toISOString() + ': name = "cpu" | view logger'
             }).catch(function(err) {
-                expect(err.message).to.include('From cannot be after to');
+                expect(err.message).to.include('-to must not be earlier than -from');
             });
         });
 


### PR DESCRIPTION
This builds on the core of #42.

As changing the API requires switching to ES6 classes (there is no equivalent ES5 way how to inherit from Adapter Read/Write on an ES6 runtime), first switch the whole project to start using them consistently across the board, then implement changes required to move to the new API in read/write and finally rename read/write classes to be consistent with other adapters.