### PR TITLE
Switch to Juttle errors in public APIs

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -5,6 +5,7 @@ var url = require('url');
 var Promise = require('bluebird');
 var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
 var AdapterRead = require('juttle/lib/runtime/adapter-read');
+var errors = require('juttle/lib/errors');
 
 var Config = require('./config');
 var Serializer = require('./serializer');
@@ -23,19 +24,26 @@ class ReadInflux extends AdapterRead {
         var unknown = _.difference(_.keys(options), allowed_options);
 
         if (unknown.length > 0) {
-            throw new Error('Unknown option ' + unknown[0]);
+            throw errors.compileError('RT-UNKNOWN-OPTION-ERROR', {
+                proc: 'read influx',
+                option: unknown[0]
+            });
         }
 
         if (options.raw) {
             if (this.options.from || this.options.to) {
-                throw new Error('-raw option should not be combined with -from, -to, or -last');
+                throw errors.compileError('RT-OPTION-FROM-TO-ERROR', {
+                    option: 'raw'
+                });
             }
 
             this.from = undefined;
             this.to = undefined;
         } else {
             if (!this.options.from && !this.options.to) {
-                throw new Error('One of -from, -to, or -last must be specified to define a query time range');
+                if (!this.options.from && !this.options.to) {
+                    throw errors.compileError('RT-MISSING-TIME-RANGE-ERROR');
+                }
             }
 
             this.from = this.options.from || params.now;
@@ -69,11 +77,11 @@ class ReadInflux extends AdapterRead {
         try {
             urlObj = url.parse(urlStr);
         } catch (e) {
-            throw new this.runtime_error('RT-INVALID-URL-ERROR', { url: urlStr });
+            throw errors.compileError('RT-INVALID-URL-ERROR', { url: urlStr });
         }
 
         if (!urlObj.host) {
-            throw new this.runtime_error('RT-INVALID-URL-ERROR', { url: urlStr });
+            throw errors.compileError('RT-INVALID-URL-ERROR', { url: urlStr });
         }
 
         return urlObj;
@@ -82,12 +90,10 @@ class ReadInflux extends AdapterRead {
     toNative(s) {
         var self = this;
         if (_.contains(s.columns, this.nameField)) {
-            self.trigger('warning',
-                    new Error(
-                        'Points contain '
-                        + this.nameField
-                        + ' field, use nameField option to make the field accessible.'
-                        ));
+            self.trigger('warning', errors.runtimeError('RT-INTERNAL-ERROR', {
+                error: 'Points contain ' + this.nameField + ' field, '
+                       + 'use nameField option to make the field accessible.'
+            }));
         }
         return _.map(s.values, function(row) {
             return self.serializer.toJuttle(s.name, s.columns, row, self.nameField);
@@ -111,7 +117,7 @@ class ReadInflux extends AdapterRead {
         var e  = _.find(data.results, 'error');
 
         if (e && e.error) {
-            throw new Error(e.error);
+            throw errors.runtimeError('RT-INTERNAL-ERROR', { error: e.error });
         }
 
         var results = _.find(data.results, 'series') || {};
@@ -154,7 +160,9 @@ class ReadInflux extends AdapterRead {
             method: 'GET'
         }).then(function(response) {
             if (response.statusCode < 200 || response.statusCode >= 300) {
-                throw new Error(response.statusCode + ': ' + response.body + ' for ' + reqUrl);
+                throw errors.runtimeError('RT-INTERNAL-ERROR', {
+                    error: response.statusCode + ': ' + response.body + ' for ' + reqUrl
+                });
             }
 
             return {

--- a/lib/write.js
+++ b/lib/write.js
@@ -4,6 +4,7 @@ var _ = require('underscore');
 var url = require('url');
 var Promise = require('bluebird');
 var AdapterWrite = require('juttle/lib/runtime/adapter-write');
+var errors = require('juttle/lib/errors');
 
 var Config = require('./config');
 var Serializer = require('./serializer');
@@ -21,7 +22,10 @@ class WriteInflux extends AdapterWrite {
         var unknown = _.difference(_.keys(options), allowed_options);
 
         if (unknown.length > 0) {
-            throw new Error('Unknown option ' + unknown[0]);
+            throw errors.compileError('RT-UNKNOWN-OPTION-ERROR', {
+                proc: 'write influx',
+                option: unknown[0]
+            });
         }
 
         this.serializer = new Serializer(_.pick(options, 'intFields', 'valFields', 'nameField'));
@@ -46,7 +50,9 @@ class WriteInflux extends AdapterWrite {
             try {
                 return self.serializer.toInflux(p, self.nameField);
             } catch(err) {
-                self.trigger('warning', err);
+                self.trigger('warning', errors.runtimeError('RT-INTERNAL-ERROR', {
+                    error: err.message
+                }));
                 return null;
             }
         })).join("\n");
@@ -59,10 +65,8 @@ class WriteInflux extends AdapterWrite {
         }).then(function(response) {
             // https://influxdb.com/docs/v0.9/guides/writing_data.html#writing-data-using-the-http-api
             // section http response summary
-            if (response.statusCode === 200) {
-                throw new Error(response.body);
-            } else if (response.statusCode > 300) {
-                throw new Error(response.body);
+            if (response.statusCode === 200 || response.statusCode > 300) {
+                throw errors.runtimeError('RT-INTERNAL-ERROR', { error: response.body });
             }
         }).catch(function(err) {
             self.trigger('error', err);

--- a/test/influx-live.spec.js
+++ b/test/influx-live.spec.js
@@ -312,7 +312,7 @@ describe('@live influxdb tests', function () {
                 return check_juttle({
                     program: 'read influx -db "test" -from :0: -limit 1 name = "namefield" | view logger'
                 }).then(function(res) {
-                    expect(res.warnings).to.deep.equal(['Points contain name field, use nameField option to make the field accessible.']);
+                    expect(res.warnings).to.deep.equal(['internal error Points contain name field, use nameField option to make the field accessible.']);
                     expect(res.sinks.logger[0].name).to.equal('namefield');
                 });
             });


### PR DESCRIPTION
Instead of throwing native JS errors, ensure we use Juttle error classes
consistently in public facing APIs.