### PR TITLE
Travis - test against stable version of juttle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,10 @@ services:
     - docker
 
 before_script:
-    - git clone https://${GITHUB_AUTH}:x-oauth-basic@github.com/juttle/juttle.git
-    - pushd juttle ; npm install ; npm link ; popd
+    - npm install juttle@0.4.x
     - ./scripts/docker.sh start
 
 script:
-    - export NODE_PATH="$(dirname `which node`)/../lib/node_modules"
     - npm test
 
 after_script:


### PR DESCRIPTION
To avoid tests breaking due to an upstream change in the middle of
release cycle, test against stable version of juttle core.

During a new release, the version in .travis.yml will be updated to
the new upstream version, and breaking changes adressed in one go.