### PR TITLE
read.js - points always contain time

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -100,15 +100,6 @@ class ReadInflux extends AdapterRead {
     }
 
     _sort(t1, t2) {
-        if (!_.has(t1, 'time') && !_.has(t2, 'time')) {
-            return 0;
-        }
-        if (!_.has(t1, 'time')) {
-            return -1;
-        }
-        if (!_.has(t2, 'time')) {
-            return 1;
-        }
         return JuttleMoment.compare(t1.time, t2.time);
     }
 


### PR DESCRIPTION
Influx always returns time, even for selects that explicitly don't list
that field. So it is safe to use native Juttle sort.