### PR TITLE
Annotate code with references to upstream bugs

### DIFF
--- a/lib/ast/rewrite/in.js
+++ b/lib/ast/rewrite/in.js
@@ -3,6 +3,10 @@
 /*
  * Rewrites juttle in operator into a sequence of ors (degenerating into a
  * simple equality for one element array and into 'false' for an empty one.
+ *
+ * Lack of IN operator is tracked in Influx issues
+ * https://github.com/influxdata/influxdb/issues/5626
+ * https://github.com/influxdata/influxdb/issues/2157
  */
 
 var ASTVisitor = require('juttle/lib/compiler/ast-visitor');

--- a/test/influx-integration.spec.js
+++ b/test/influx-integration.spec.js
@@ -324,7 +324,7 @@ describe('@integration influxdb tests', () => {
                 });
             });
 
-            // Possibly bug in Influx, this actually returns all records
+            // Bug: https://github.com/influxdata/influxdb/issues/5152
             it.skip('compound on tags and values', () => {
                 return check_juttle({
                     program: 'read influx -db "test" -from :0: name = "cpu" and (value = 1 or host = "host5") | view logger'
@@ -332,6 +332,17 @@ describe('@integration influxdb tests', () => {
                     expect(res.sinks.logger.length).to.equal(2);
                     expect(res.sinks.logger[0].value).to.equal(1);
                     expect(res.sinks.logger[1].host).to.equal('host5');
+                });
+            });
+
+            // Bug: https://github.com/influxdata/influxdb/issues/5152
+            it.skip('compound inequalities on tags and values', () => {
+                return check_juttle({
+                    program: 'read influx -db "test" -from :0: name = "cpu" and (value < 1 or host > "host8") | view logger'
+                }).then((res) => {
+                    expect(res.sinks.logger.length).to.equal(2);
+                    expect(res.sinks.logger[0].value).to.equal(0);
+                    expect(res.sinks.logger[1].host).to.equal('host9');
                 });
             });
 


### PR DESCRIPTION
Certain issues are not in the adapter, but are caused by an underlying bug
in influx. Add links to the upstream bugs on github.