### PR TITLE
Disallow writes of null and regexp values

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -76,6 +76,12 @@ class Serializer {
         if (values.isDate(v) || values.isDuration(v)) {
             return [k, v.unixms()];
         } else
+        if (values.isRegExp(v)) {
+            throw new Error('Serializing regular expression values is not supported.');
+        } else
+        if (values.isNull(v)) {
+            throw new Error('Serializing null values is not supported.');
+        } else
         if (values.isObject(v) || values.isArray(v)) {
             throw new Error('Serializing array and object fields is not supported.');
         } else {

--- a/test/serializer.spec.js
+++ b/test/serializer.spec.js
@@ -155,6 +155,16 @@ describe('serialization', () => {
             expect(serializer.toInflux.bind(serializer, point, '_name')).to.throw(Error, /not supported/);
         });
 
+        it('serializing nulls throws an error', () => {
+            var point = { nil: null, _name: 'n' };
+            expect(serializer.toInflux.bind(serializer, point, '_name')).to.throw(Error, /not supported/);
+        });
+
+        it('serializing regexes throws an error', () => {
+            var point = { reg: /abcd/, _name: 'n' };
+            expect(serializer.toInflux.bind(serializer, point, '_name')).to.throw(Error, /not supported/);
+        });
+
         describe('nameField option', () => {
             it('defaults to name', () => {
                 var serializer = new Serializer();


### PR DESCRIPTION
Influx doesn't support writing nulls and regexp data types.