### PR TITLE
Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,9 @@ services:
     - docker
 
 before_script:
+    - rm -rf node_modules/juttle
     - npm install $JUTTLE_PACKAGE
+    - pushd node_modules/juttle; npm install; popd
     - ./scripts/docker.sh start
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: node_js
 
-cache:
-  directories:
-    - node_modules
-
 addons:
   apt:
     sources:
@@ -19,14 +15,16 @@ node_js:
     - '5.0'
 
 env:
-    - INFLUX_VERSION=0.9
-    - INFLUX_VERSION=0.10
+    - INFLUX_VERSION=0.9 JUTTLE_PACKAGE=juttle/juttle
+    - INFLUX_VERSION=0.9 JUTTLE_PACKAGE=juttle@0.4.x
+    - INFLUX_VERSION=0.10 JUTTLE_PACKAGE=juttle/juttle
+    - INFLUX_VERSION=0.10 JUTTLE_PACKAGE=juttle@0.4.x
 
 services:
     - docker
 
 before_script:
-    - npm install juttle@0.4.x
+    - npm install $JUTTLE_PACKAGE
     - ./scripts/docker.sh start
 
 script:


### PR DESCRIPTION
Enable travis builds for juttle master, but allow them to fail. This should serve as an early warning against breaking changes in core.