### PR TITLE
Remove redundant condition

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -48,9 +48,7 @@ class ReadInflux extends AdapterRead {
             this.to = undefined;
         } else {
             if (!this.options.from && !this.options.to) {
-                if (!this.options.from && !this.options.to) {
-                    throw errors.compileError('RT-MISSING-TIME-RANGE-ERROR');
-                }
+                throw errors.compileError('RT-MISSING-TIME-RANGE-ERROR');
             }
 
             this.from = this.options.from || params.now;

--- a/test/influx-integration.spec.js
+++ b/test/influx-integration.spec.js
@@ -155,6 +155,14 @@ describe('@integration influxdb tests', () => {
             });
         });
 
+        it('reports error without -from, -to or -last', () => {
+            return check_juttle({
+                program: 'read influx -db "test" value = 1 | view logger'
+            }).catch((err) => {
+                expect(err.message).to.include('One of -from, -to, or -last must be specified to define a query time range');
+            });
+        });
+
         it('basic select', () => {
             return check_juttle({
                 program: 'read influx -db "test" -from :0: name = "cpu" | view logger'


### PR DESCRIPTION
Remove redundant if. Checking once for the same thing should be enough for everybody. Also add test for time range options.