### PR TITLE
write.js: split data into chunks on write

### DIFF
--- a/lib/write.js
+++ b/lib/write.js
@@ -25,6 +25,10 @@ class WriteInflux extends AdapterWrite {
         this.db = options.db || 'test';
         this.url = Config.get().url;
         this.pendingWrites = 0;
+
+        // Writes need to be chunked, ~200k point bulk writes result in influx
+        // timing out. Let's be conservative.
+        this.writeChunkSize = 10000;
     }
 
     // FIXME: Why doesn't write provide commonOptions, while read does?
@@ -53,19 +57,27 @@ class WriteInflux extends AdapterWrite {
                 }));
                 return null;
             }
-        })).join("\n");
+        }));
+
+        var writeChunks = [];
+        while (body.length > 0) {
+            writeChunks.push(body.splice(0, this.writeChunkSize));
+        }
 
         this.pendingWrites++;
-        return request.async({
-            url: reqUrl,
-            method: 'POST',
-            body
-        }).then((response) => {
-            // https://influxdb.com/docs/v0.9/guides/writing_data.html#writing-data-using-the-http-api
-            // section http response summary
-            if (response.statusCode === 200 || response.statusCode > 300) {
-                throw this.runtimeError('INTERNAL-ERROR', { error: response.body });
-            }
+
+        return Promise.each(writeChunks, (chunk) => {
+            return request.async({
+                url: reqUrl,
+                method: 'POST',
+                body: chunk.join('\n')
+            }).then((response) => {
+                // https://influxdb.com/docs/v0.9/guides/writing_data.html#writing-data-using-the-http-api
+                // section http response summary
+                if (response.statusCode === 200 || response.statusCode > 300) {
+                    throw this.runtimeError('INTERNAL-ERROR', { error: response.body });
+                }
+            });
         }).catch((err) => {
             this.trigger('error', err);
         }).then(() => {


### PR DESCRIPTION
Influx times out on writing ~200k points during a single request.
Split the body into chunks of 10k points and send the requests
separately.

What we lose by this is that if single request fails, the previous
writes are not rolled back.