### PR TITLE
Use error helpers instead of calling error.X methods

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -7,7 +7,6 @@ var Promise = require('bluebird');
 /* global JuttleAdapterAPI */
 var JuttleMoment = JuttleAdapterAPI.types.JuttleMoment;
 var AdapterRead = JuttleAdapterAPI.AdapterRead;
-var errors = JuttleAdapterAPI.errors;
 
 var Config = require('./config');
 var Serializer = require('./serializer');
@@ -22,14 +21,14 @@ class ReadInflux extends AdapterRead {
 
         if (options.raw) {
             if (params.filter_ast !== null) {
-                throw errors.compileError('INVALID-OPTION-COMBINATION', {
+                throw this.compileError('INVALID-OPTION-COMBINATION', {
                     option: 'raw',
                     rule: 'empty filter'
                 });
             }
 
             if (this.options.from || this.options.to) {
-                throw errors.compileError('OPTION-FROM-TO-ERROR', {
+                throw this.compileError('OPTION-FROM-TO-ERROR', {
                     option: 'raw'
                 });
             }
@@ -38,7 +37,7 @@ class ReadInflux extends AdapterRead {
             this.to = undefined;
         } else {
             if (!this.options.from && !this.options.to) {
-                throw errors.compileError('MISSING-TIME-RANGE');
+                throw this.compileError('MISSING-TIME-RANGE');
             }
 
             this.from = this.options.from || params.now;
@@ -80,11 +79,11 @@ class ReadInflux extends AdapterRead {
         try {
             urlObj = url.parse(urlStr);
         } catch (e) {
-            throw errors.compileError('INVALID-URL-ERROR', { url: urlStr });
+            throw this.compileError('INVALID-URL-ERROR', { url: urlStr });
         }
 
         if (!urlObj.host) {
-            throw errors.compileError('INVALID-URL-ERROR', { url: urlStr });
+            throw this.compileError('INVALID-URL-ERROR', { url: urlStr });
         }
 
         return urlObj;
@@ -93,7 +92,7 @@ class ReadInflux extends AdapterRead {
     toNative(s) {
         var self = this;
         if (_.contains(s.columns, this.nameField)) {
-            self.trigger('warning', errors.runtimeError('INTERNAL-ERROR', {
+            self.trigger('warning', this.runtimeError('INTERNAL-ERROR', {
                 error: `Points contain ${this.nameField} field, use nameField option to make the field accessible.`
             }));
         }
@@ -110,7 +109,7 @@ class ReadInflux extends AdapterRead {
         var e  = _.find(data.results, 'error');
 
         if (e && e.error) {
-            throw errors.runtimeError('INTERNAL-ERROR', { error: e.error });
+            throw this.runtimeError('INTERNAL-ERROR', { error: e.error });
         }
 
         var results = _.find(data.results, 'series') || {};
@@ -155,7 +154,7 @@ class ReadInflux extends AdapterRead {
             method: 'GET'
         }).then((response) => {
             if (response.statusCode < 200 || response.statusCode >= 300) {
-                throw errors.runtimeError('INTERNAL-ERROR', {
+                throw this.runtimeError('INTERNAL-ERROR', {
                     error: `${response.statusCode}: ${response.body} for ${reqUrl}`
                 });
             }

--- a/lib/write.js
+++ b/lib/write.js
@@ -6,7 +6,6 @@ var Promise = require('bluebird');
 
 /* global JuttleAdapterAPI */
 var AdapterWrite = JuttleAdapterAPI.AdapterWrite;
-var errors = JuttleAdapterAPI.errors;
 
 var Config = require('./config');
 var Serializer = require('./serializer');
@@ -49,7 +48,7 @@ class WriteInflux extends AdapterWrite {
             try {
                 return this.serializer.toInflux(p, this.nameField);
             } catch(err) {
-                this.trigger('warning', errors.runtimeError('INTERNAL-ERROR', {
+                this.trigger('warning', this.runtimeError('INTERNAL-ERROR', {
                     error: err.message
                 }));
                 return null;
@@ -65,7 +64,7 @@ class WriteInflux extends AdapterWrite {
             // https://influxdb.com/docs/v0.9/guides/writing_data.html#writing-data-using-the-http-api
             // section http response summary
             if (response.statusCode === 200 || response.statusCode > 300) {
-                throw errors.runtimeError('INTERNAL-ERROR', { error: response.body });
+                throw this.runtimeError('INTERNAL-ERROR', { error: response.body });
             }
         }).catch((err) => {
             this.trigger('error', err);


### PR DESCRIPTION
AdapterRead and AdapterWrite expose error helpers in the base classes.

Use them instead of importing error related functions from the Adapter
API.