### PR TITLE
read.js - fix handling of query limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Currently supports InfluxDB 0.9 and 0.10.
 
 ## Examples
 
-Read entries from the `cpu` measurement where the `host` tag is `www123` and the default limit of 1000:
+Read entries from the `cpu` measurement where the `host` tag is `www123`:
 
 ```juttle
 read influx -db 'test' name='cpu' host='www123' | view text
@@ -18,7 +18,7 @@ read influx -db 'test' name='cpu' host='www123' | view text
 Perform an equivalent query using the -raw option:
 
 ```juttle
-read influx -db 'test' -raw "SELECT * FROM cpu where host='www123 LIMIT 1000' | view text
+read influx -db 'test' -raw "SELECT * FROM cpu where host='www123' | view text
 ```
 
 Write a single point into the `cpu` measurement:
@@ -81,8 +81,6 @@ Name | Type | Required | Description
 -----|------|----------|-------------
 `db`   | string | yes | database to use
 `raw`  | string | no  | send a raw InfluxQL query to InfluxDB
-`offset` | integer| no | record offset
-`limit`  | integer | no | query limit (default: 1000)
 `fields` | string | no | fields to select from the measurement (default: all)
 `nameField` | string | no | if specified, measurement name will be saved in a point field with this name (default: 'name')
 `from` | moment | no | select points after this time (inclusive)

--- a/lib/read.js
+++ b/lib/read.js
@@ -51,14 +51,20 @@ class ReadInflux extends AdapterRead {
         this.db = options.db;
 
         this.queryBuilder = new QueryBuilder();
-        this.queryOptimization = params.optimization_info;
+
+        // Maximum points per read to fetch.
+        this.maxReadSize = 10000;
+
+        // Keep track of points, so that we can read only up to optimization
+        // limit.
+        this.pointsRead = 0;
 
         this.queryOptions = _.defaults(
             _.pick(options, 'fields', 'raw'),
-            this.queryOptimization.options || {},
+            params.optimization_info.options || {},
             {
                 nameField: this.nameField,
-                limit: 1000,
+                limit: Infinity
             }
         );
 
@@ -142,7 +148,11 @@ class ReadInflux extends AdapterRead {
         var parsedUrl = _.clone(this.url);
         var reqUrl = null;
 
-        var queryOptions = _.extend({ to, from }, this.queryOptions);
+        // Don't rely on scheduler giving us a sane limit and instead use our
+        // own treshold.
+        var fetchSize = Math.min(limit, this.maxReadSize, this.queryOptions.limit - this.pointsRead);
+
+        var queryOptions = _.defaults({ to, from, limit: fetchSize }, this.queryOptions);
         var query = this.queryBuilder.build(queryOptions, this.queryFilter);
 
         this.logger.debug(`Running query: ${query}`);
@@ -159,8 +169,11 @@ class ReadInflux extends AdapterRead {
                 });
             }
 
+            var points = self.parse(JSON.parse(response.body));
+            this.pointsRead += points.length;
+
             return {
-                points: self.parse(JSON.parse(response.body)),
+                points: points,
                 readEnd: to || new JuttleMoment(Infinity)
             };
         }).catch((e) => {

--- a/lib/read.js
+++ b/lib/read.js
@@ -54,7 +54,7 @@ class ReadInflux extends AdapterRead {
         this.queryOptimization = params.optimization_info;
 
         this.queryOptions = _.defaults(
-            _.pick(options, 'offset', 'limit', 'fields', 'raw'),
+            _.pick(options, 'fields', 'raw'),
             this.queryOptimization.options || {},
             {
                 nameField: this.nameField,
@@ -66,7 +66,7 @@ class ReadInflux extends AdapterRead {
     }
 
     static allowedOptions() {
-        return AdapterRead.commonOptions().concat(['db', 'optimize', 'limit', 'offset', 'raw', 'nameField', 'fields']);
+        return AdapterRead.commonOptions().concat(['db', 'optimize', 'raw', 'nameField', 'fields']);
     }
 
     static requiredOptions() {

--- a/test/influx-integration.spec.js
+++ b/test/influx-integration.spec.js
@@ -186,17 +186,9 @@ describe('@integration influxdb tests', () => {
             });
         });
 
-        it('limit', () => {
-            return check_juttle({
-                program: 'read influx -db "test" -from :0: -limit 5 name = "cpu" | view logger'
-            }).then((res) => {
-                expect(res.sinks.logger.length).to.equal(5);
-            });
-        });
-
         it('fields', () => {
             return check_juttle({
-                program: 'read influx -db "test" -from :0: -limit 1 -fields "value" name = "cpu" | view logger'
+                program: 'read influx -db "test" -from :0: -fields "value" name = "cpu" | head 1 | view logger'
             }).then((res) => {
                 expect(_.keys(res.sinks.logger[0])).to.deep.equal(['time', 'value', 'name']);
                 expect(res.sinks.logger[0].value).to.equal(0);
@@ -205,7 +197,7 @@ describe('@integration influxdb tests', () => {
 
         it('fields reports error if values not included', () => {
             return check_juttle({
-                program: 'read influx -db "test" -from :0: -limit 1 -fields "host" name = "cpu" | view logger'
+                program: 'read influx -db "test" -from :0: -fields "host" name = "cpu" | head 1 | view logger'
             }).then((res) => {
                 expect(res.errors[0]).to.include('at least one field in select clause');
             });
@@ -525,7 +517,7 @@ describe('@integration influxdb tests', () => {
 
             it('overwrites the name by default and triggers a warning', () => {
                 return check_juttle({
-                    program: 'read influx -db "test" -from :0: -limit 1 name = "namefield" | view logger'
+                    program: 'read influx -db "test" -from :0: name = "namefield" | head 1 | view logger'
                 }).then((res) => {
                     expect(res.warnings).to.deep.equal(['internal error Points contain name field, use nameField option to make the field accessible.']);
                     expect(res.sinks.logger[0].name).to.equal('namefield');
@@ -534,7 +526,7 @@ describe('@integration influxdb tests', () => {
 
             it('selects metric and stores its name based on nameField', () => {
                 return check_juttle({
-                    program: 'read influx -db "test" -from :0: -nameField "metric" -limit 1 metric = "namefield" | view logger'
+                    program: 'read influx -db "test" -from :0: -nameField "metric" metric = "namefield" | head 1 | view logger'
                 }).then((res) => {
                     expect(res.sinks.logger[0].name).to.equal('conflict');
                     expect(res.sinks.logger[0].metric).to.equal('namefield');
@@ -559,22 +551,6 @@ describe('@integration influxdb tests', () => {
                         expect(res.sinks.logger.length).to.equal(3);
                     });
                 });
-
-                it('head n doesnt override limit', () => {
-                    return check_juttle({
-                        program: 'read influx -db "test" -limit 1 -from :0: name = "cpu" | head 3 | view logger'
-                    }).then((res) => {
-                        expect(res.sinks.logger.length).to.equal(1);
-                    });
-                });
-
-                it('head n doesnt override limit, unoptimized', () => {
-                    return check_juttle({
-                        program: 'read influx -optimize false -db "test" -limit 1 -from :0: name = "cpu" | head 3 | view logger'
-                    }).then((res) => {
-                        expect(res.sinks.logger.length).to.equal(1);
-                    });
-                });
             });
 
             describe('tail', () => {
@@ -595,22 +571,6 @@ describe('@integration influxdb tests', () => {
                         expect(res.sinks.logger.length).to.equal(3);
                         expect(res.sinks.logger[0].value).to.equal(7);
                         expect(res.sinks.logger[2].value).to.equal(9);
-                    });
-                });
-
-                it('tail n doesnt override limit', () => {
-                    return check_juttle({
-                        program: 'read influx -db "test" -limit 1 -from :0: name = "cpu" | tail 3 | view logger'
-                    }).then((res) => {
-                        expect(res.sinks.logger.length).to.equal(1);
-                    });
-                });
-
-                it('tail n doesnt override limit, unoptimized', () => {
-                    return check_juttle({
-                        program: 'read influx -optimize false -db "test" -limit 1 -from :0: name = "cpu" | tail 3 | view logger'
-                    }).then((res) => {
-                        expect(res.sinks.logger.length).to.equal(1);
                     });
                 });
             });


### PR DESCRIPTION
There was a bug in read that caused only 1k of points to be fetched by
default.

Update the limit-handling code so that:

1. User choices override optimization settings

2. When base class calls `read()` to fetch more points, we keep track
   of points fetched, and compute the limit as a minimum from the
   `batchSize` parameter passed to us and the remaining points to be
   read in total.