### PR TITLE
Add performance tests for influx serialization

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -38,44 +38,55 @@ class Serializer {
     toInflux(point, nameField) {
         if (!nameField) { throw new Error('nameField argument required'); }
 
+        // Measurement name
         var name = point[nameField];
-        var timestamp_ns = point.time ? point.time.unixms() : null;
-
-        point = _.omit(point, nameField, 'time');
-
-        var tags = _.pick(point, this._isTag.bind(this));
-        var vals = _.omit(point, this._isTag.bind(this));
-
-        if (_.keys(vals).length === 0) { throw new Error('point requires at least one field'); }
         if (!name) { throw new Error('point is missing a name'); }
 
-        var key = _.flatten([name, _.map(tags, this._concatKeyVal)]).map(this._escapeTag);
+        // Timestamp
+        var timestamp = point.time ? point.time.unixms() : '';
+        var point = _.omit(point, nameField, 'time');
 
-        var val = _.chain(vals)
-                   .map(this._serializeValue.bind(this))
-                   .object()
-                   .map(this._concatKeyVal)
-                   .value();
+        // Tags, values
+        var tags = _.pick(point, (val, key) => {
+            return _.isString(val) && !_.contains(this.valFields, key);
+        });
 
-        return _.compact([key.join(","), val.join(","), timestamp_ns]).join(" ");
+        var vals = _.omit(point, (val, key) => {
+            return _.isString(val) && !_.contains(this.valFields, key);
+        });
+
+        // Drop point early, influx wont accept this
+        if (_.keys(vals).length === 0) { throw new Error('point requires at least one field'); }
+
+        // left column - name + tags
+        var taggedName = [
+            this._escapeTag(name)
+        ].concat(
+            _.map(tags, (val, key) => {
+                return this._escapeTag(`${key}=${val}`);
+            })
+        ).join(",");
+
+        // middle column
+        var values = _.map(vals, (val, key) => {
+            return `${key}=${this._serializeValue(key, val, this.intFields)}`;
+        }).join(",");
+
+        return `${taggedName} ${values} ${timestamp}`.trim();
     }
 
-    _concatKeyVal(v, k) {
-        return `${k}=${v}`;
-    }
-
-    _serializeValue(v, k) {
+    _serializeValue(k, v, intFields) {
         if (values.isBoolean(v)) {
-            return [k, (v ? 't' : 'f')];
+            return (v ? 't' : 'f');
         } else
         if (values.isString(v)) {
-            return [k, `"${this._escapeString(v)}"`];
+            return `"${this._escapeString(v)}"`;
         } else
-        if (this._isInt(v, k)) {
-            return [k, `${Math.floor(v)}i`];
+        if (_.isNumber(v) && _.contains(intFields, k)) {
+            return `${Math.floor(v)}i`;
         } else
         if (values.isDate(v) || values.isDuration(v)) {
-            return [k, v.unixms()];
+            return v.unixms();
         } else
         if (values.isRegExp(v)) {
             throw new Error('Serializing regular expression values is not supported.');
@@ -86,27 +97,18 @@ class Serializer {
         if (values.isObject(v) || values.isArray(v)) {
             throw new Error('Serializing array and object fields is not supported.');
         } else {
-            return [k, v];
+            return v;
         }
     }
 
     // https://influxdb.com/docs/v0.9/write_protocols/line.html#key
     _escapeTag(str) {
-        var specialChars = /[\s,]/g;
-        return str.replace(specialChars, m => { return `\\${m}`; });
+        return str.replace(/[\s,]/g, "\\$&");
     }
 
     // https://influxdb.com/docs/v0.9/write_protocols/line.html#fields (Strings)
     _escapeString(str) {
         return str.replace(/"/g, '\\"');
-    }
-
-    _isTag(val, key, obj) {
-        return _.isString(val) && !_.contains(this.valFields, key);
-    }
-
-    _isInt(val, key, obj) {
-        return _.isNumber(val) && _.contains(this.intFields, key);
     }
 }
 

--- a/lib/write.js
+++ b/lib/write.js
@@ -48,7 +48,15 @@ class WriteInflux extends AdapterWrite {
 
         reqUrl = url.format(parsedUrl);
 
-        var body = _.compact(_.map(points, (p) => {
+        var rows = this.serialize(points);
+
+        var chunks = this.chunkRows(rows, this.writeChunkSize);
+
+        return this.sendWrites(reqUrl, chunks);
+    }
+
+    serialize(points) {
+        return _.compact(_.map(points, (p) => {
             try {
                 return this.serializer.toInflux(p, this.nameField);
             } catch(err) {
@@ -58,10 +66,6 @@ class WriteInflux extends AdapterWrite {
                 return null;
             }
         }));
-
-        var chunks = this.writeChunks(body, this.writeChunkSize);
-
-        return this.sendWrites(reqUrl, chunks);
     }
 
     sendWrites(url, chunks) {
@@ -77,7 +81,7 @@ class WriteInflux extends AdapterWrite {
         });
     }
 
-    writeChunks(body, writeChunkSize) {
+    chunkRows(body, writeChunkSize) {
         var writeChunks = [];
         while (body.length > 0) {
             writeChunks.push(body.splice(0, writeChunkSize));

--- a/lib/write.js
+++ b/lib/write.js
@@ -59,14 +59,11 @@ class WriteInflux extends AdapterWrite {
             }
         }));
 
-        var writeChunks = [];
-        while (body.length > 0) {
-            writeChunks.push(body.splice(0, this.writeChunkSize));
-        }
+        var chunks = this.writeChunks(body, this.writeChunkSize);
 
         this.pendingWrites++;
 
-        return Promise.each(writeChunks, (chunk) => {
+        return Promise.each(chunks, (chunk) => {
             return this.request(reqUrl, chunk);
         }).catch((err) => {
             this.trigger('error', err);
@@ -74,6 +71,14 @@ class WriteInflux extends AdapterWrite {
             this.pendingWrites--;
             this.checkIfDone();
         });
+    }
+
+    writeChunks(body, writeChunkSize) {
+        var writeChunks = [];
+        while (body.length > 0) {
+            writeChunks.push(body.splice(0, writeChunkSize));
+        }
+        return writeChunks;
     }
 
     request(reqUrl, chunk) {

--- a/lib/write.js
+++ b/lib/write.js
@@ -67,22 +67,26 @@ class WriteInflux extends AdapterWrite {
         this.pendingWrites++;
 
         return Promise.each(writeChunks, (chunk) => {
-            return request.async({
-                url: reqUrl,
-                method: 'POST',
-                body: chunk.join('\n')
-            }).then((response) => {
-                // https://influxdb.com/docs/v0.9/guides/writing_data.html#writing-data-using-the-http-api
-                // section http response summary
-                if (response.statusCode === 200 || response.statusCode > 300) {
-                    throw this.runtimeError('INTERNAL-ERROR', { error: response.body });
-                }
-            });
+            return this.request(reqUrl, chunk);
         }).catch((err) => {
             this.trigger('error', err);
         }).then(() => {
             this.pendingWrites--;
             this.checkIfDone();
+        });
+    }
+
+    request(reqUrl, chunk) {
+        return request.async({
+            url: reqUrl,
+            method: 'POST',
+            body: chunk.join('\n')
+        }).then((response) => {
+            // https://influxdb.com/docs/v0.9/guides/writing_data.html#writing-data-using-the-http-api
+            // section http response summary
+            if (response.statusCode === 200 || response.statusCode > 300) {
+                throw this.runtimeError('INTERNAL-ERROR', { error: response.body });
+            }
         });
     }
 

--- a/lib/write.js
+++ b/lib/write.js
@@ -61,10 +61,14 @@ class WriteInflux extends AdapterWrite {
 
         var chunks = this.writeChunks(body, this.writeChunkSize);
 
+        return this.sendWrites(reqUrl, chunks);
+    }
+
+    sendWrites(url, chunks) {
         this.pendingWrites++;
 
         return Promise.each(chunks, (chunk) => {
-            return this.request(reqUrl, chunk);
+            return this.request(url, chunk);
         }).catch((err) => {
             this.trigger('error', err);
         }).then(() => {
@@ -81,9 +85,9 @@ class WriteInflux extends AdapterWrite {
         return writeChunks;
     }
 
-    request(reqUrl, chunk) {
+    request(url, chunk) {
         return request.async({
-            url: reqUrl,
+            url: url,
             method: 'POST',
             body: chunk.join('\n')
         }).then((response) => {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "test": "mocha test/**/*.spec.js test/*.spec.js",
     "lint": "eslint --ignore-pattern=./coverage/ .",
-    "cov": "istanbul cover _mocha && istanbul check-coverage",
+    "cov": "istanbul cover _mocha test/**/*.spec.js test/*.spec.js && istanbul check-coverage",
     "perf": "node ./test/performance/index.js"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "test": "mocha",
     "lint": "eslint --ignore-pattern=./coverage/ .",
-    "cov": "istanbul cover _mocha && istanbul check-coverage"
+    "cov": "istanbul cover _mocha && istanbul check-coverage",
+    "perf": "node ./test/performance/index.js"
   },
   "dependencies": {
     "glob-to-regexp": "^0.1.0",
@@ -30,6 +31,8 @@
     "mocha": "^2.3.4",
     "eslint": "^1.10.3",
     "istanbul": "^0.4.2",
+    "microtime": "2.0.0",
+    "benchmark": "2.1.0",
     "bluebird-retry": "^0.5.2"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "main": "index.js",
   "repository": "juttle/juttle-influx-adapter",
   "scripts": {
-    "test": "mocha",
+    "test": "mocha test/**/*.spec.js test/*.spec.js",
     "lint": "eslint --ignore-pattern=./coverage/ .",
     "cov": "istanbul cover _mocha && istanbul check-coverage",
     "perf": "node ./test/performance/index.js"

--- a/test/influx-integration.spec.js
+++ b/test/influx-integration.spec.js
@@ -8,9 +8,6 @@ var path = require('path');
 var Promise = require('bluebird');
 var retry = require('bluebird-retry');
 
-var request = Promise.promisifyAll(require('request'));
-request.async = Promise.promisify(request);
-
 var juttle_test_utils = require('juttle/test').utils;
 var check_juttle = juttle_test_utils.check_juttle;
 
@@ -19,82 +16,22 @@ var retry_options = {
     timeout: 2000
 };
 
-var influx_api_url = {
+var influx_api_url = url.format({
     protocol: 'http',
     hostname: process.env.INFLUX_HOST || 'localhost',
     port: process.env.INFLUX_PORT || 8086,
     pathname: '/'
-};
+});
+
+var DB = require('./test_utils').DB.init(influx_api_url);
 
 juttle_test_utils.configureAdapter({
     influx: {
         path: path.resolve(__dirname, '..'),
-        url: url.format(influx_api_url)
+        url: influx_api_url
     }
 });
 
-/* DB utils */
-var DB = {
-    // Influx doesnt seem to like writing future points?
-    _t0: Date.now() - 3600 * 1000,
-    _points: 10,
-    _dt: 1000,
-
-    _handle_response(response) {
-        if (response.statusCode !== 200 && response.statusCode !== 204) {
-            throw new Error(['error', response.statusCode, response.body].join(' '));
-        }
-
-        return response.body === "" ? null : JSON.parse(response.body);
-    },
-
-    _fixture() {
-        var payload = "";
-
-        for (var i = 0; i < this._points; i++) {
-            var t_i = this._t0 + i * this._dt;
-            payload += `cpu,host=host${i} value=${i} ${t_i}\n`;
-        }
-
-        for (var j = 0; j < this._points; j++) {
-            var t_j = this._t0 + j * this._dt;
-            payload += `mem,host=host${j} value=${j} ${t_j}\n`;
-        }
-
-        return payload;
-    },
-
-    query(q) {
-        var requestUrl = _.extend(influx_api_url, { pathname: '/query', query: { q, 'db': 'test' } });
-        return request.async({
-            url: url.format(requestUrl),
-            method: 'GET'
-        }).then(this._handle_response).catch((e) => {
-            throw e;
-        });
-    },
-
-    create() {
-        return this.query('CREATE DATABASE test');
-    },
-
-    drop() {
-        return this.query('DROP DATABASE test');
-    },
-
-    insert(data) {
-        var payload = data || this._fixture();
-        var requestUrl = _.extend(influx_api_url, { pathname: '/write', query: { 'db': 'test', 'precision': 'ms' } });
-
-        return request.async({
-            url: url.format(requestUrl),
-            method: 'POST',
-            body: payload
-        }).then(this._handle_response).catch((e) => {
-            throw e;
-        });
-    },
-};
 
 describe('@integration influxdb tests', () => {
     describe('read', () => {

--- a/test/performance/index.js
+++ b/test/performance/index.js
@@ -1,0 +1,2 @@
+require('./serializer/influx');
+require('./serializer/juttle');

--- a/test/performance/index.js
+++ b/test/performance/index.js
@@ -1,2 +1,5 @@
 require('./serializer/influx');
 require('./serializer/juttle');
+require('./write/serialize.js');
+require('./write/stubbed.js');
+require('./write/live.js');

--- a/test/performance/serializer/influx.js
+++ b/test/performance/serializer/influx.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var Benchmark = require('benchmark');
+var withAdapterAPI = require('juttle/test').utils.withAdapterAPI;
+
+withAdapterAPI(() => {
+    global.Serializer = require('../../../lib/serializer');
+    global.JuttleMoment = JuttleAdapterAPI.types.JuttleMoment;
+
+    new Benchmark.Suite().add('serializer.toInflux', {
+        setup: () => {
+            var serializer = new Serializer();
+            var point = { tag: 'one', another: 'two', num: 1.1, _name: 'n', time: new JuttleMoment(Date.now()) };
+        },
+        fn: () => {
+            serializer.toInflux(point, '_name');
+        },
+        onError: (e) => {
+             console.log(e.message)
+        }
+    }).on('cycle', (event) => {
+        console.log(String(event.target));
+    }).run();
+});

--- a/test/performance/serializer/juttle.js
+++ b/test/performance/serializer/juttle.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var Benchmark = require('benchmark');
+var withAdapterAPI = require('juttle/test').utils.withAdapterAPI;
+
+withAdapterAPI(() => {
+    global.Serializer = require('../../../lib/serializer');
+
+    new Benchmark.Suite().add('serializer.toJuttle', {
+        setup: () => {
+            var serializer = new Serializer();
+            var name = "cpu";
+            var keys = ["tag", "another", "num", "time"];
+            var values = ["one", "two", 1.1, Date.now()];
+            var nameField = "name";
+        },
+        fn: () => {
+            serializer.toJuttle(name, keys, values, nameField);
+        },
+        onError: (e) => {
+            console.log(e.message)
+        }
+    }).on('cycle', (event) => {
+        console.log(String(event.target));
+    }).run();
+});

--- a/test/performance/write/live.js
+++ b/test/performance/write/live.js
@@ -1,0 +1,55 @@
+'use strict';
+
+var Benchmark = require('benchmark');
+var withAdapterAPI = require('juttle/test').utils.withAdapterAPI;
+var Promise = require('bluebird');
+
+withAdapterAPI(() => {
+    global._ = require('underscore');
+    global.JuttleMoment = JuttleAdapterAPI.types.JuttleMoment;
+    global.AdapterWrite = require('../../../lib/write');
+    global.Config = require('../../../lib/config');
+
+    global.pointsInBatch = 1000;
+    global.iterations = 0;
+
+    var url =  'http://localhost:8086/';
+    Config.set({url: url});
+
+    var DB = require('../../test_utils/').DB.init(url);
+
+    return DB.drop().then(() => { return DB.create(); }).then(() => {
+        return new Promise((resolve, reject) => {
+            new Benchmark.Suite().add('AdapterWrite.write, live request, 1k points/call', {
+                setup: () => {
+                    var adapterWrite = new AdapterWrite({}, {});
+                    var points = _.times(pointsInBatch, (i) => {
+                        return {
+                            tag: 'one' + (iterations * pointsInBatch) + i,
+                            another: 'two' + (iterations * pointsInBatch) + i,
+                            num: 1.1 + (iterations * pointsInBatch) + i,
+                            name: 'n',
+                            time: new JuttleMoment(iterations * pointsInBatch + i)
+                        }
+                    });
+                },
+                teardown: () => {
+                    iterations += 1;
+                },
+                fn: (deferred) => {
+                    adapterWrite.write(points).then(function() { deferred.resolve(); });
+                },
+                onError: (e) => {
+                    console.log(e.message)
+                    reject();
+                },
+                defer: true
+            }).on('cycle', (event) => {
+                console.log(String(event.target));
+                resolve();
+            }).run();
+        });
+    }).finally(() => {
+        return DB.drop();
+    });
+});

--- a/test/performance/write/serialize.js
+++ b/test/performance/write/serialize.js
@@ -1,0 +1,43 @@
+'use strict';
+
+var Benchmark = require('benchmark');
+var withAdapterAPI = require('juttle/test').utils.withAdapterAPI;
+var Promise = require('bluebird');
+
+withAdapterAPI(() => {
+    global._ = require('underscore');
+    global.JuttleMoment = JuttleAdapterAPI.types.JuttleMoment;
+    global.AdapterWrite = require('../../../lib/write');
+    global.Config = require('../../../lib/config');
+
+    global.pointsInBatch = 1000;
+    global.iterations = 0;
+
+    Config.set({url: 'http://localhost:8086/'});
+
+    new Benchmark.Suite().add('AdapterWrite.serialize, 1k points/call', {
+        setup: () => {
+            var adapterWrite = new AdapterWrite({}, {});
+            var points = _.times(pointsInBatch, (i) => {
+                return {
+                    tag: 'one' + (iterations * pointsInBatch) + i,
+                    another: 'two' + (iterations * pointsInBatch) + i,
+                    num: 1.1 + (iterations * pointsInBatch) + i,
+                    name: 'n',
+                    time: new JuttleMoment(iterations * pointsInBatch + i)
+                }
+            });
+        },
+        teardown: () => {
+            iterations += 1;
+        },
+        fn: () => {
+            adapterWrite.serialize(points);
+        },
+        onError: (e) => {
+            console.log(e.message)
+        }
+    }).on('cycle', (event) => {
+        console.log(String(event.target));
+    }).run();
+});

--- a/test/performance/write/stubbed.js
+++ b/test/performance/write/stubbed.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var Benchmark = require('benchmark');
+var withAdapterAPI = require('juttle/test').utils.withAdapterAPI;
+var Promise = require('bluebird');
+
+withAdapterAPI(() => {
+    global._ = require('underscore');
+    global.JuttleMoment = JuttleAdapterAPI.types.JuttleMoment;
+    global.AdapterWrite = require('../../../lib/write');
+    global.Config = require('../../../lib/config');
+
+    global.pointsInBatch = 1000;
+    global.iterations = 0;
+
+    Config.set({url: 'http://localhost:8086/'});
+
+    new Benchmark.Suite().add('AdapterWrite.write, stubbed request, 1k points/call', {
+        setup: () => {
+            var adapterWrite = new AdapterWrite({}, {});
+
+            adapterWrite.request = (reqUrl, chunk) => { chunk.join('\n'); return Promise.resolve(); };
+
+            var points = _.times(pointsInBatch, (i) => {
+                return {
+                    tag: 'one' + (iterations * pointsInBatch) + i,
+                    another: 'two' + (iterations * pointsInBatch) + i,
+                    num: 1.1 + (iterations * pointsInBatch) + i,
+                    name: 'n',
+                    time: new JuttleMoment(iterations * pointsInBatch + i)
+                }
+            });
+        },
+        teardown: () => {
+            iterations += 1;
+        },
+        fn: (deferred) => {
+            adapterWrite.write(points).then(function() { deferred.resolve(); });
+        },
+        onError: (e) => {
+            console.log(e.message)
+        },
+        defer: true
+    }).on('cycle', (event) => {
+        console.log(String(event.target));
+    }).run();
+});

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -1,15 +1,5 @@
-var SemanticPass = require('juttle/lib/compiler/semantic');
-var FilterSimplifier = require('juttle/lib/compiler/filters/filter-simplifier');
-
-var parser = require('juttle/lib/parser');
-var semantic = new SemanticPass({ now: Date.now() });
-var simplifier = new FilterSimplifier();
+var parseFilter = require('./test_utils/parse_filter');
 
 module.exports = {
-    parseFilter(code) {
-        var root = parser.parseFilter(code);
-        semantic.sa_expr(root.ast);
-        root.ast = simplifier.simplify(root.ast);
-        return root;
-    }
+    parseFilter
 };

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -1,5 +1,0 @@
-var parseFilter = require('./test_utils/parse_filter');
-
-module.exports = {
-    parseFilter
-};

--- a/test/test_utils/db.js
+++ b/test/test_utils/db.js
@@ -1,0 +1,74 @@
+var _ = require('underscore');
+var url = require('url');
+var Promise = require('bluebird');
+var request = Promise.promisifyAll(require('request'));
+request.async = Promise.promisify(request);
+
+var DB = {
+    // Influx doesnt seem to like writing future points?
+    _t0: Date.now() - 3600 * 1000,
+    _points: 10,
+    _dt: 1000,
+
+    init(urlString) {
+        this.url = url.parse(urlString);
+        return this;
+    },
+
+    _handle_response(response) {
+        if (response.statusCode !== 200 && response.statusCode !== 204) {
+            throw new Error(['error', response.statusCode, response.body].join(' '));
+        }
+
+        return response.body === "" ? null : JSON.parse(response.body);
+    },
+
+    _fixture() {
+        var payload = "";
+
+        for (var i = 0; i < this._points; i++) {
+            var t_i = this._t0 + i * this._dt;
+            payload += `cpu,host=host${i} value=${i} ${t_i}\n`;
+        }
+
+        for (var j = 0; j < this._points; j++) {
+            var t_j = this._t0 + j * this._dt;
+            payload += `mem,host=host${j} value=${j} ${t_j}\n`;
+        }
+
+        return payload;
+    },
+
+    query(q) {
+        var requestUrl = _.extend(this.url, { pathname: '/query', query: { q, 'db': 'test' } });
+        return request.async({
+            url: url.format(requestUrl),
+            method: 'GET'
+        }).then(this._handle_response).catch((e) => {
+            throw e;
+        });
+    },
+
+    create() {
+        return this.query('CREATE DATABASE test');
+    },
+
+    drop() {
+        return this.query('DROP DATABASE test');
+    },
+
+    insert(data) {
+        var payload = data || this._fixture();
+        var requestUrl = _.extend(this.url, { pathname: '/write', query: { 'db': 'test', 'precision': 'ms' } });
+
+        return request.async({
+            url: url.format(requestUrl),
+            method: 'POST',
+            body: payload
+        }).then(this._handle_response).catch((e) => {
+            throw e;
+        });
+    },
+};
+
+module.exports = DB;

--- a/test/test_utils/index.js
+++ b/test/test_utils/index.js
@@ -1,5 +1,7 @@
 var parseFilter = require('./parse_filter');
+var DB = require('./db');
 
 module.exports = {
-    parseFilter
+    parseFilter,
+    DB
 };

--- a/test/test_utils/index.js
+++ b/test/test_utils/index.js
@@ -1,0 +1,5 @@
+var parseFilter = require('./parse_filter');
+
+module.exports = {
+    parseFilter
+};

--- a/test/test_utils/parse_filter.js
+++ b/test/test_utils/parse_filter.js
@@ -1,0 +1,15 @@
+var SemanticPass = require('juttle/lib/compiler/semantic');
+var FilterSimplifier = require('juttle/lib/compiler/filters/filter-simplifier');
+
+var parser = require('juttle/lib/parser');
+var semantic = new SemanticPass({ now: Date.now() });
+var simplifier = new FilterSimplifier();
+
+function parseFilter(code) {
+    var root = parser.parseFilter(code);
+    semantic.sa_expr(root.ast);
+    root.ast = simplifier.simplify(root.ast);
+    return root;
+}
+
+module.exports = parseFilter;


### PR DESCRIPTION
The benchmarks can be run using `npm run-script -s perf`.