### PR TITLE
lint: use global JuttleAdapterAPI

### DIFF
--- a/lib/ast/lint.js
+++ b/lib/ast/lint.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var ASTVisitor = require('juttle/lib/compiler/ast-visitor');
+/* global JuttleAdapterAPI */
+var ASTVisitor = JuttleAdapterAPI.compiler.ASTVisitor;
 var ast_utils = require('./utils');
 
 class Linter extends ASTVisitor {

--- a/test/ast/lint.spec.js
+++ b/test/ast/lint.spec.js
@@ -4,6 +4,10 @@ var expect = require('chai').expect;
 var _ = require('underscore');
 var utils = require('../test_utils');
 
+var withAdapterAPI = require('juttle/test').utils.withAdapterAPI;
+
+withAdapterAPI(() => {
+
 var Linter = require('../../lib/ast/lint');
 
 describe('query linting', () => {
@@ -181,4 +185,6 @@ describe('query linting', () => {
             expect(linter.lint.bind(linter, ast, { nameField: 'name' })).to.throw(/Full text search is not supported/);
         });
     });
+});
+
 });


### PR DESCRIPTION
There was a stray require() which wasn't properly converted to the
new Adapter API so it failed when juttle wasn't resolvable in the
require path.