### PR TITLE
update to juttle 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 This file documents all notable changes to Juttle Influx Adapter. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## 0.7.0
+
+Released 2016-03-23
+
+- Updated to support Juttle 0.7.0.
+
 ## 0.6.0
 
 Released 2016-03-10

--- a/lib/ast/lint.js
+++ b/lib/ast/lint.js
@@ -64,6 +64,10 @@ class Linter extends ASTVisitor {
         }
     }
 
+    visitMemberExpression(node, op, options) {
+        throw new Error('Nested fields not supported by InfluxQL');
+    }
+
     visit(node, options) {
         if (ast_utils.isNameField(node, options.nameField) && options.disallowNameField) {
             throw new Error(`${options.nameField} cannot be nested inside the filter.`);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "continuation-local-storage": "~3",
     "underscore": "^1.8.3"
   },
-  "juttleAdapterAPI": "^0.5.2",
+  "juttleAdapterAPI": "^0.7.0",
   "devDependencies": {
     "chai": "^3.4.1",
     "mocha": "^2.3.4",

--- a/test/ast/lint.spec.js
+++ b/test/ast/lint.spec.js
@@ -185,6 +185,20 @@ describe('query linting', () => {
             expect(linter.lint.bind(linter, ast, { nameField: 'name' })).to.throw(/Full text search is not supported/);
         });
     });
+
+    it('doesnt allow nested field filters', () => {
+        var tests = [
+            'obj.field == 1',
+            'obj.field == "2"',
+            'obj.field != 3',
+            'obj.field < 4',
+        ];
+
+        _.each(tests, (test) => {
+            var ast = utils.parseFilter(test);
+            expect(linter.lint.bind(linter, ast, { nameField: 'name' })).to.throw(/Nested fields not supported/);
+        });
+    });
 });
 
 });


### PR DESCRIPTION
Bump the package.json to the new adapter API.
Add a check for nested fields in the query parsing.
Update the changelog for the pending release.
